### PR TITLE
Highlight matched query segments in command palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file. (Notable ch
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+
+- Highlight matched query segments in command palette ([#72](https://github.com/text-forge/text-forge/pull/72)
+
 ## [0.1] - 2025-7-27 (Beta)
 
 ### Added

--- a/action_scripts/scenes/command_pallete.gd
+++ b/action_scripts/scenes/command_pallete.gd
@@ -15,11 +15,14 @@ func _ready() -> void:
 
 func _on_line_edit_text_changed(new_text: String) -> void:
 	var order := commands.keys()
-	order.sort_custom(func(a, b): return new_text.similarity(a) > new_text.similarity(b))
+	order.sort_custom(_sort_commands.bind(new_text))
 	SLib.free_all_children(options)
-	for item in order:
+	for item: String in order:
 		var option: Button = sample.duplicate()
-		option.text = item
+		var modified_text = item
+		if item.containsn(new_text):
+			modified_text = item.substr(0, item.findn(new_text)) + "[bgcolor=ffffff10]" + item.substr(item.findn(new_text), new_text.length()) + "[/bgcolor]" + item.substr(item.findn(new_text) + new_text.length())
+		option.get_child(1).append_text(modified_text)
 		option.get_child(0).text = commands[item][0]
 		if option.get_child(0).text == "(Unset)": option.get_child(0).hide()
 		option.pressed.connect(commands[item][1])
@@ -27,6 +30,22 @@ func _on_line_edit_text_changed(new_text: String) -> void:
 		options.add_child(option)
 		option.show()
 	options.set_deferred("scroll_horizontal", 0)
+
+
+func _sort_commands(a: String, b: String, text: String) -> bool:
+	var score_a: float = text.similarity(a)
+	var score_b: float = text.similarity(b)
+
+	if a.contains(text):
+		score_a += 1
+	elif a.containsn(text):
+		score_a += 0.5
+	if b.contains(text):
+		score_b += 1
+	elif b.containsn(text):
+		score_b += 0.5
+
+	return score_a > score_b
 
 
 func _on_line_edit_text_submitted(new_text: String) -> void:

--- a/action_scripts/scenes/command_pallete.tscn
+++ b/action_scripts/scenes/command_pallete.tscn
@@ -8,7 +8,7 @@ font_color = Color(1, 1, 1, 0.34902)
 
 [node name="Popup" type="Popup" node_paths=PackedStringArray("options", "sample", "input")]
 initial_position = 2
-size = Vector2i(400, 245)
+size = Vector2i(400, 282)
 visible = true
 script = ExtResource("1_2hb76")
 options = NodePath("PanelContainer/VBoxContainer/ScrollContainer/VBoxContainer")
@@ -32,6 +32,7 @@ placeholder_text = "Search for command"
 [node name="ScrollContainer" type="ScrollContainer" parent="PanelContainer/VBoxContainer"]
 custom_minimum_size = Vector2(0, 200)
 layout_mode = 2
+size_flags_vertical = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/VBoxContainer/ScrollContainer"]
 layout_mode = 2
@@ -41,6 +42,13 @@ size_flags_vertical = 3
 [node name="Button" type="Button" parent="PanelContainer/VBoxContainer"]
 visible = false
 layout_mode = 2
+theme_override_colors/font_disabled_color = Color(0, 0, 0, 0)
+theme_override_colors/font_hover_pressed_color = Color(0, 0, 0, 0)
+theme_override_colors/font_hover_color = Color(0, 0, 0, 0)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 0)
+theme_override_colors/font_color = Color(0, 0, 0, 0)
+theme_override_colors/font_focus_color = Color(0, 0, 0, 0)
+theme_override_colors/font_pressed_color = Color(0, 0, 0, 0)
 text = "New"
 alignment = 0
 text_overrun_behavior = 3
@@ -60,6 +68,22 @@ grow_vertical = 2
 text = "Ctrl+F"
 label_settings = SubResource("LabelSettings_x336v")
 horizontal_alignment = 1
+vertical_alignment = 1
+text_overrun_behavior = 1
+
+[node name="RichTextLabel" type="RichTextLabel" parent="PanelContainer/VBoxContainer/Button"]
+layout_mode = 1
+anchors_preset = 4
+anchor_top = 0.5
+anchor_bottom = 0.5
+offset_left = 5.0
+offset_top = -11.5
+offset_right = 244.0
+offset_bottom = 11.5
+grow_vertical = 2
+mouse_filter = 1
+bbcode_enabled = true
+scroll_active = false
 vertical_alignment = 1
 
 [connection signal="text_changed" from="PanelContainer/VBoxContainer/LineEdit" to="." method="_on_line_edit_text_changed"]


### PR DESCRIPTION
This change adds highlight to match section of command name in command list, also have a higher score for `contains` (+1) and `containsn` (+0.5) to make sure they will be in top. This highlighter isn't case sensitive as you can see in screenshot.
<img width="404" height="287" alt="image" src="https://github.com/user-attachments/assets/ed1db00b-db0d-4c8e-81e0-5ec7b2c590b6" />
