### PR TITLE
Add automatic load last opened file at start feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default directory for export modes / packages (System documents directory) ([#75](https://github.com/text-forge/text-forge/pull/75))
 - Automaticaly navigating to last opened file in "Open" file dialog ([#75](https://github.com/text-forge/text-forge/pull/75))
 - Automaticaly navigating to current saved file in "Save As" file dialog ([#75](https://github.com/text-forge/text-forge/pull/75))
+- Automaticaly load last opened file at start ([#77](https://github.com/text-forge/text-forge/pull/77))
 
 ### Changed
 

--- a/action_scripts/scenes/preferences.tscn
+++ b/action_scripts/scenes/preferences.tscn
@@ -5,7 +5,7 @@
 [node name="Preferences" type="Window" node_paths=PackedStringArray("container", "tree")]
 title = "Preferences"
 initial_position = 2
-size = Vector2i(600, 400)
+size = Vector2i(700, 400)
 popup_window = true
 min_size = Vector2i(400, 300)
 script = ExtResource("1_huy1r")

--- a/core/main.gd
+++ b/core/main.gd
@@ -57,12 +57,18 @@ func _ready() -> void:
 	# Connect reload_recent_files request signal
 	Signals.reload_recent_files.connect(_reload_recent_files)
 
+	Settings.define_preset("files", "load_last_file_at_start", true)
+	Settings.define_preset("files", "ask_before_load_last_file_at_start", false)
+	Settings.define_preset("notifications", "automatic_load_last_file_at_start", true)
+
 	# load data in main_menu_data
 	_load_main_menu_data()
 	# Load main menu items
 	_load_main_menu()
 	# Load action scripts
 	_load_scripts()
+
+	_handle_load_last_file()
 
 
 ## Appends [param file_path] in [constant FileDatabase.RECENT_FILES_DATA]. New file will be in top
@@ -86,6 +92,21 @@ func append_to_recent_files(file_path: String) -> void:
 
 func show_about() -> void:
 	about.show()
+
+
+func _handle_load_last_file() -> void:
+	if not(Settings.get_setting("files", "load_last_file_at_start") and Global.get_last_file_path()):
+		return
+
+	if Settings.get_setting("files", "ask_before_load_last_file_at_start"):
+		add_child(Factory.confirmation_dialog("Do you want to load your last opened file?", "Yes", "No", "Load last file", Callable(), _load_last_file.bind(false), true))
+	else:
+		_load_last_file(true)
+
+func _load_last_file(is_automatic := true) -> void:
+	Signals.open_file.emit(Global.get_last_file_path())
+	if is_automatic and Settings.get_setting("notifications", "automatic_load_last_file_at_start"):
+		Global.send_notification(Global.Notification.INFO, "Your last opened file was loaded!", "You can change this behavior or disable this notification in preferences.")
 
 
 ## Loads data in [member main_menu_data], uses [constant FileDatabase.MAIN_UI_DATA] and [constant DATA_SECTION].


### PR DESCRIPTION
This merge adds load last opened file at start feature with three new options in preferences:
- `files > load_last_file_at_start`
  When `true` will launching the next option.
- `files > ask_before_load_last_file_at_start`
  Works when `files > load_last_file_at_start` is `true`. When `true` will show popup dialog and ask user choice, when `false` load last opened file automatically.
- `notifications > automatic_load_last_file_at_start`
  If this feature load file automatically, when `true` sends a notification to say file loaded.

Overview of feature:
```
if (has last opened file)
    if (files > load_last_file_at_start)
        if (files > ask_before_load_last_file_at_start)
            show popup
            if (user select load last file)
                load file
        else
            load file
            if (notifications > automatic_load_last_file_at_start)
                send notification
```