### PR TITLE
Add scroll container for preferences tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automaticaly navigating to last opened file in "Open" file dialog ([#75](https://github.com/text-forge/text-forge/pull/75))
 - Automaticaly navigating to current saved file in "Save As" file dialog ([#75](https://github.com/text-forge/text-forge/pull/75))
 - Automaticaly load last opened file at start ([#77](https://github.com/text-forge/text-forge/pull/77))
+- Scrolling for preferences tabs ([#78](https://github.com/text-forge/text-forge/pull/78))
 
 ### Changed
 

--- a/action_scripts/scenes/preferences.gd
+++ b/action_scripts/scenes/preferences.gd
@@ -12,17 +12,21 @@ func _ready() -> void:
 	config.load(Settings.PRESETS_FILE)
 	tree.create_item()
 	for section in config.get_sections():
+		var scroll := ScrollContainer.new()
+		scroll.add_theme_stylebox_override("panel", preload("res://data/margin_style_box_empty.tres"))
 		var tab := VBoxContainer.new()
+		tab.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 		for item in config.get_section_keys(section):
 			var option = load("res://action_scripts/scenes/setting_option.tscn").instantiate()
 			option.section = section
 			option.key = item
 			tab.add_child(option)
-		tab.name = section.capitalize().replace("Ui", "UI")
-		container.add_child(tab)
+		scroll.name = section.capitalize().replace("Ui", "UI")
+		scroll.add_child(tab)
+		container.add_child(scroll)
 		var page := tree.create_item()
-		page.set_text(0, tab.name)
-		if tab.get_child_count() == 0: tab.queue_free()
+		page.set_text(0, scroll.name)
+		if tab.get_child_count() == 0: scroll.queue_free()
 	if tree.get_root().get_child_count():
 		tree.set_selected(tree.get_root().get_first_child(),0)
 

--- a/data/margin_style_box_empty.tres
+++ b/data/margin_style_box_empty.tres
@@ -1,0 +1,7 @@
+[gd_resource type="StyleBoxEmpty" format=3 uid="uid://b5tnv0o6axvf5"]
+
+[resource]
+content_margin_left = 5.0
+content_margin_top = 5.0
+content_margin_right = 5.0
+content_margin_bottom = 5.0


### PR DESCRIPTION
## Type of Change
- [X] UI/UX improvement (change enhancing user interface and experience)

## Description of the UI/UX Improvement
This PR add a `ScrollContainer` as parent of each tab in preferences window, this change will fix higher height than window height in long tabs with a lot of items. Also, will make horizontal scroll bars for long item names.

## Impact of the Improvement
Will be more stable for future based on increasing number of options. Also, there is a currently fixed bug in "Editor UI" tab.

## Testing Conducted
Tested in smallest and default size with high height and width. Changing tabs works fine and empty tabs will remove as before.

## Screenshots/Videos (if applicable)
<img width="702" height="439" alt="image" src="https://github.com/user-attachments/assets/d8ac2c2c-91af-4848-9302-44b01a990feb" />

## Checklist

- [X] The UI/UX improvements enhance user interaction and experience.
- [X] I have tested the changes across different screen sizes and devices.
- [X] The improvements are visually appealing and accessible.
- [X] I have documented the rationale behind the UI/UX changes.
- [X] User feedback, if available, has been considered and incorporated.
