### PR TITLE
Safer line folding toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Wrong `queue_free()` call for standard file dialogs ([#75](https://github.com/text-forge/text-forge/pull/75))
+- **Action Script:** Safer disabling for View > Show Fold Gutter ([#79](https://github.com/text-forge/text-forge/pull/79))
 
 ## [0.1] - 2025-7-27 (Beta)
 

--- a/action_scripts/show_fold_gutter.gd
+++ b/action_scripts/show_fold_gutter.gd
@@ -7,6 +7,7 @@ func _setup() -> void:
 
 func _set_value(to: bool) -> void:
 	Global.get_editor().gutters_draw_fold_gutter = to
+	Global.get_editor().line_folding = to
 
 func _get_value() -> bool:
 	return Global.get_editor().gutters_draw_fold_gutter


### PR DESCRIPTION
Adds changing for `line_folding` property of editor to make changes in `show fold gutter` safer.