### PR TITLE
Add Change Log into About panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automaticaly load last opened file at start ([#77](https://github.com/text-forge/text-forge/pull/77))
 - Scrolling for preferences tabs ([#78](https://github.com/text-forge/text-forge/pull/78))
 - polski translation `PL` ([#84](https://github.com/text-forge/text-forge/pull/84))
+- Added Change Log tab to About panel ([#83](https://github.com/text-forge/text-forge/pull/83))
 
 ### Changed
 

--- a/core/main.tscn
+++ b/core/main.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=8 format=3 uid="uid://dx1alvj3tjt16"]
+[gd_scene load_steps=9 format=3 uid="uid://dx1alvj3tjt16"]
 
 [ext_resource type="Script" uid="uid://byayvu15ojy1j" path="res://core/main.gd" id="1_o5qli"]
 [ext_resource type="Script" uid="uid://dfy2sbtb4i0ht" path="res://core/scripts/panel_manager.gd" id="2_tefeu"]
 [ext_resource type="Script" uid="uid://5cin2ow0mkq0" path="res://core/scripts/module_profiler.gd" id="5_xa854"]
+[ext_resource type="Script" uid="uid://dg7rms2cwflkl" path="res://core/scripts/change_log.gd" id="6_kagtj"]
 [ext_resource type="Script" uid="uid://d0j1s4uv04c3w" path="res://core/scripts/editor_api.gd" id="6_tefeu"]
 [ext_resource type="Script" uid="uid://dtusvq1vqt0ul" path="res://core/scripts/editor.gd" id="7_tipki"]
 
@@ -262,6 +263,16 @@ text = "[b]Icons:[/b]
 		Main UI: MIT 2025 by Mahan Khalili
 
 [i]See [code]\"root/modes/\"[/code], [code]\"root/scripts/\"[/code], [code]\"userdata/extensions\"[/code] for other licenses. Modes, scripts and extensions without LICENSE file are onder Text Forge license."
+
+[node name="Change Log" type="MarginContainer" parent="About/MarginContainer/TabContainer"]
+visible = false
+layout_mode = 2
+script = ExtResource("6_kagtj")
+metadata/_tab_index = 4
+
+[node name="Text" type="RichTextLabel" parent="About/MarginContainer/TabContainer/Change Log"]
+layout_mode = 2
+bbcode_enabled = true
 
 [connection signal="text_changed" from="Margin/Sections/PanelManager/LeftSpliter/RightSpliter/BottomSpliter/Editor" to="." method="_on_editor_text_changed"]
 [connection signal="timeout" from="Margin/Sections/HBoxContainer/ModuleProfiler/Timer" to="Margin/Sections/HBoxContainer/ModuleProfiler" method="_refresh"]

--- a/core/main.tscn
+++ b/core/main.tscn
@@ -264,10 +264,11 @@ text = "[b]Icons:[/b]
 
 [i]See [code]\"root/modes/\"[/code], [code]\"root/scripts/\"[/code], [code]\"userdata/extensions\"[/code] for other licenses. Modes, scripts and extensions without LICENSE file are onder Text Forge license."
 
-[node name="Change Log" type="MarginContainer" parent="About/MarginContainer/TabContainer"]
+[node name="Change Log" type="MarginContainer" parent="About/MarginContainer/TabContainer" node_paths=PackedStringArray("label")]
 visible = false
 layout_mode = 2
 script = ExtResource("6_kagtj")
+label = NodePath("Text")
 metadata/_tab_index = 4
 
 [node name="Text" type="RichTextLabel" parent="About/MarginContainer/TabContainer/Change Log"]

--- a/core/scripts/change_log.gd
+++ b/core/scripts/change_log.gd
@@ -1,24 +1,27 @@
 extends Node
 
 
+@export var label: RichTextLabel
+
+
 func _ready() -> void:
 	var markdown_text: String = FileAccess.get_file_as_string("res://CHANGELOG.md")
 	var bbcode_text: String = _convert_text_from_markdown_to_bbcode_style(markdown_text)
-	$Text.text = bbcode_text
+	label.text = bbcode_text
 
 
 func _convert_text_from_markdown_to_bbcode_style(markdown_text: String) -> String:
 	var text: String = markdown_text
 	
-	# H1 headers: # Header1 -> [font_size=24][b][u]Header1[/u][/b][/font_size]
+	# H1 headers: # Header1 -> [font_size=24][b]Header1[/b][/font_size]
 	var h1_regex: RegEx = RegEx.new()
 	h1_regex.compile(r"(?m)^# (.+)$")
-	text = h1_regex.sub(text, "[font_size=24][b][u]$1[/u][/b][/font_size]", true)
+	text = h1_regex.sub(text, "[font_size=24][b]$1[/b][/font_size]", true)
 	
-	# H2 headers: ## Header2 -> [font_size=20][b][u]Header2[/u][/b][/font_size]
+	# H2 headers: ## Header2 -> [font_size=20][b]Header2[/b][/font_size]
 	var h2_regex: RegEx = RegEx.new()
 	h2_regex.compile(r"(?m)^## (.+)$")
-	text = h2_regex.sub(text, "[font_size=20][b][u]$1[/u][/b][/font_size]", true)
+	text = h2_regex.sub(text, "[font_size=20][b]$1[/b][/font_size]", true)
 	
 	# H3 headers: ### Header3 -> [font_size=16][b]Header3[/b][/font_size]
 	var h3_regex: RegEx = RegEx.new()
@@ -40,9 +43,27 @@ func _convert_text_from_markdown_to_bbcode_style(markdown_text: String) -> Strin
 	link_regex.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 	text = link_regex.sub(text, "[url=$2]$1[/url]", true)
 	
+	# Commit SHA: ([SHA]()) -> ([code]SHA[/code])
+	var sha_regex: RegEx = RegEx.new()
+	sha_regex.compile(r"\(\[([0-9a-f]{7})\]\(\)\)")
+	text = sha_regex.sub(text, "([code]$1[/code])", true)
+	
 	# Lists: - item -> • item
 	var list_regex: RegEx = RegEx.new()
 	list_regex.compile(r"(?m)^- ")
 	text = list_regex.sub(text, "• ", true)
+	
+	# Version links: [label]: url -> [url=url]label[/url]
+	var version_link_regex: RegEx = RegEx.new()
+	version_link_regex.compile(r"^\[([^\]]+)\]:\s*(https?://[^\s]+)$")
+	var version_link_dict: Dictionary[String, String] = {}
+	for line in text.split("\n"):
+		var matched_string: RegExMatch = version_link_regex.search(line)
+		if matched_string:
+			version_link_dict[matched_string.get_string(1)] = matched_string.get_string(2)
+			text = text.replace(line + "\n", "")
+	
+	for version in version_link_dict.keys():
+		text = text.replace("[%s]" % version, "[url=%s]%s[/url]" % [version_link_dict[version], version])
 	
 	return text

--- a/core/scripts/change_log.gd
+++ b/core/scripts/change_log.gd
@@ -2,25 +2,25 @@ extends Node
 
 
 func _ready() -> void:
-	var raw_markdown: String = FileAccess.get_file_as_string("res://CHANGELOG.md")
-	var text_converted_to_bbcode: String = markdown_to_bbcode(raw_markdown)
-	$Text.text = text_converted_to_bbcode
+	var text_markdown: String = FileAccess.get_file_as_string("res://CHANGELOG.md")
+	var text_bbcode: String = _convert_text_from_markdown_to_bbcode_style(text_markdown)
+	$Text.text = text_bbcode
 
 
-func markdown_to_bbcode(markdown_text: String) -> String:
+func _convert_text_from_markdown_to_bbcode_style(markdown_text: String) -> String:
 	var text: String = markdown_text
 	
-	# H1 headers: # Something -> [font_size=24][b][u]Something[/u][/b][/font_size]
+	# H1 headers: # Header1 -> [font_size=24][b][u]Header1[/u][/b][/font_size]
 	var h1_regex: RegEx = RegEx.new()
 	h1_regex.compile(r"(?m)^# (.+)$")
 	text = h1_regex.sub(text, "[font_size=24][b][u]$1[/u][/b][/font_size]", true)
 	
-	# H2 headers: ## Something -> [font_size=20][b][u]Something[/u][/b][/font_size]
+	# H2 headers: ## Header2 -> [font_size=20][b][u]Header2[/u][/b][/font_size]
 	var h2_regex: RegEx = RegEx.new()
 	h2_regex.compile(r"(?m)^## (.+)$")
 	text = h2_regex.sub(text, "[font_size=20][b][u]$1[/u][/b][/font_size]", true)
 	
-	# H3 headers: ### Something -> [font_size=16][b]Something[/b][/font_size]
+	# H3 headers: ### Header3 -> [font_size=16][b]Header3[/b][/font_size]
 	var h3_regex: RegEx = RegEx.new()
 	h3_regex.compile(r"(?m)^### (.+)$")
 	text = h3_regex.sub(text, "[font_size=16][b]$1[/b][/font_size]", true)

--- a/core/scripts/change_log.gd
+++ b/core/scripts/change_log.gd
@@ -2,9 +2,9 @@ extends Node
 
 
 func _ready() -> void:
-	var text_markdown: String = FileAccess.get_file_as_string("res://CHANGELOG.md")
-	var text_bbcode: String = _convert_text_from_markdown_to_bbcode_style(text_markdown)
-	$Text.text = text_bbcode
+	var markdown_text: String = FileAccess.get_file_as_string("res://CHANGELOG.md")
+	var bbcode_text: String = _convert_text_from_markdown_to_bbcode_style(markdown_text)
+	$Text.text = bbcode_text
 
 
 func _convert_text_from_markdown_to_bbcode_style(markdown_text: String) -> String:

--- a/core/scripts/change_log.gd
+++ b/core/scripts/change_log.gd
@@ -10,7 +10,7 @@ func _ready() -> void:
 func markdown_to_bbcode(markdown_text: String) -> String:
 	var text: String = markdown_text
 	
-	# H1 headers: ## Something -> [font_size=24][b][u]Something[/u][/b]
+	# H1 headers: # Something -> [font_size=24][b][u]Something[/u][/b]
 	var h1_regex: RegEx = RegEx.new()
 	h1_regex.compile(r"(?m)^# (.+)$")
 	text = h1_regex.sub(text, "[font_size=24][b][u]$1[/u][/b][/font_size]", true)

--- a/core/scripts/change_log.gd
+++ b/core/scripts/change_log.gd
@@ -10,17 +10,17 @@ func _ready() -> void:
 func markdown_to_bbcode(markdown_text: String) -> String:
 	var text: String = markdown_text
 	
-	# H1 headers: # Something -> [font_size=24][b][u]Something[/u][/b]
+	# H1 headers: # Something -> [font_size=24][b][u]Something[/u][/b][/font_size]
 	var h1_regex: RegEx = RegEx.new()
 	h1_regex.compile(r"(?m)^# (.+)$")
 	text = h1_regex.sub(text, "[font_size=24][b][u]$1[/u][/b][/font_size]", true)
 	
-	# H2 headers: ## Something -> [font_size=20][b][u]Something[/u][/b]
+	# H2 headers: ## Something -> [font_size=20][b][u]Something[/u][/b][/font_size]
 	var h2_regex: RegEx = RegEx.new()
 	h2_regex.compile(r"(?m)^## (.+)$")
 	text = h2_regex.sub(text, "[font_size=20][b][u]$1[/u][/b][/font_size]", true)
 	
-	# H3 headers: ### Something -> [font_size=16][b]Something[/b]
+	# H3 headers: ### Something -> [font_size=16][b]Something[/b][/font_size]
 	var h3_regex: RegEx = RegEx.new()
 	h3_regex.compile(r"(?m)^### (.+)$")
 	text = h3_regex.sub(text, "[font_size=16][b]$1[/b][/font_size]", true)

--- a/core/scripts/change_log.gd
+++ b/core/scripts/change_log.gd
@@ -1,0 +1,48 @@
+extends Node
+
+
+func _ready() -> void:
+	var raw_markdown: String = FileAccess.get_file_as_string("res://CHANGELOG.md")
+	var text_converted_to_bbcode: String = markdown_to_bbcode(raw_markdown)
+	$Text.text = text_converted_to_bbcode
+
+
+func markdown_to_bbcode(markdown_text: String) -> String:
+	var text: String = markdown_text
+	
+	# H1 headers: ## Something -> [font_size=24][b][u]Something[/u][/b]
+	var h1_regex: RegEx = RegEx.new()
+	h1_regex.compile(r"(?m)^# (.+)$")
+	text = h1_regex.sub(text, "[font_size=24][b][u]$1[/u][/b][/font_size]", true)
+	
+	# H2 headers: ## Something -> [font_size=20][b][u]Something[/u][/b]
+	var h2_regex: RegEx = RegEx.new()
+	h2_regex.compile(r"(?m)^## (.+)$")
+	text = h2_regex.sub(text, "[font_size=20][b][u]$1[/u][/b][/font_size]", true)
+	
+	# H3 headers: ### Something -> [font_size=16][b]Something[/b]
+	var h3_regex: RegEx = RegEx.new()
+	h3_regex.compile(r"(?m)^### (.+)$")
+	text = h3_regex.sub(text, "[font_size=16][b]$1[/b][/font_size]", true)
+	
+	# Bold: **text** -> [b]text[/b]
+	var bold_regex: RegEx = RegEx.new()
+	bold_regex.compile(r"\*\*(.+?)\*\*")
+	text = bold_regex.sub(text, "[b]$1[/b]", true)
+	
+	# Inline code: `code` -> [code]code[/code]
+	var code_regex: RegEx = RegEx.new()
+	code_regex.compile(r"`([^`]+)`")
+	text = code_regex.sub(text, "[code]$1[/code]", true)
+	
+	# Links: [title](url) -> [url=url]title[/url]
+	var link_regex: RegEx = RegEx.new()
+	link_regex.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+	text = link_regex.sub(text, "[url=$2]$1[/url]", true)
+	
+	# Lists: - item -> • item
+	var list_regex: RegEx = RegEx.new()
+	list_regex.compile(r"(?m)^- ")
+	text = list_regex.sub(text, "• ", true)
+	
+	return text

--- a/core/scripts/change_log.gd.uid
+++ b/core/scripts/change_log.gd.uid
@@ -1,0 +1,1 @@
+uid://dg7rms2cwflkl


### PR DESCRIPTION
# Pull Request Template

## Title
Add Change Log into About panel

## Type of Change
- [x] New feature

## Description
This closes #34 
Added a new tab into the About panel.
The text is loaded from the CHANGELOG.md file.
The text is converted from markdown to bbcode style with RegEx for headers, bold style, inline code, links and lists.

## Testing
Tested that the window is showing and hiding properly and that the displayed text is showing properly with correct styling.

## Impact
The text is loaded in about 0.3ms at the start of the app, so no impact on performance.

## Additional Information
My solution doesn't cover all markup styling, only the ones most commonly used in the change log.
I tested the [MarkdownLabel](https://github.com/daenvil/MarkdownLabel) addon and it works fine as well, but it was significantly heavier on the performance (50ms vs my 0.3ms) and bring a lot more files with almost the same final effect.
If there is a need to have a full support of markdown style, this addon can be added instead and reused in the Change Log.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings 
