### PR TITLE
Add new saved/loaded file to recent files

### DIFF
--- a/action_scripts/open.gd
+++ b/action_scripts/open.gd
@@ -19,17 +19,4 @@ func _open_file(path: String) -> void:
 	Global.set_file_name(path.get_file())
 	Global.set_file_path(path)
 	Global.get_editor_api().load_file(path)
-	_append_to_recent_files(path)
 	Signals.check_options.emit()
-
-
-func _append_to_recent_files(path: String) -> void:
-	var file = FileAccess.open(FileDatabase.RECENT_FILES_DATA, FileAccess.READ)
-	var files = file.get_as_text() if FileAccess.file_exists(SLib.globalize_path(FileDatabase.RECENT_FILES_DATA)) else ""
-	if FileAccess.file_exists(SLib.globalize_path(FileDatabase.RECENT_FILES_DATA)):
-		file.close()
-	file = FileAccess.open(FileDatabase.RECENT_FILES_DATA, FileAccess.WRITE)
-	file.store_string(path + "\n" + files)
-	file.close()
-	Signals.reload_recent_files.emit()
-	menu.set_item_disabled(menu.get_item_index(id + 1), Global.get_core().recent_files_submenu.item_count == 0)

--- a/core/main.gd
+++ b/core/main.gd
@@ -354,7 +354,7 @@ func _reload_recent_files() -> void:
 	if FileAccess.file_exists(SLib.globalize_path(FileDatabase.RECENT_FILES_DATA)):
 		var recent_files_list = FileAccess.get_file_as_string(FileDatabase.RECENT_FILES_DATA).split("\n", false)
 
-		recent_files_list = SLib.merge_unique(recent_files_list, []) # Remove repeated items
+		recent_files_list = SLib.merge_unique(recent_files_list, []) # Remove duplicate items
 
 		for recent in recent_files_list:
 			if recent_files_submenu.item_count == 15: # Limit list to 15 items
@@ -364,10 +364,11 @@ func _reload_recent_files() -> void:
 
 			recent_files_submenu.add_item(recent.replace("\\", "/"))
 
-	# Save recent files (to remove repeated and non-existent items)
+	# Save recent files again (to remove repeated and non-existent items)
 	var recent_files := PackedStringArray()
 	for recent in recent_files_submenu.item_count:
 		recent_files.append(recent_files_submenu.get_item_text(recent))
-	var file = FileAccess.open(FileDatabase.RECENT_FILES_DATA, FileAccess.WRITE)
-	file.store_string("\n".join(recent_files))
-	file.close()
+	if "\n".join(recent_files) != FileAccess.get_file_as_string(FileDatabase.RECENT_FILES_DATA):
+		var file = FileAccess.open(FileDatabase.RECENT_FILES_DATA, FileAccess.WRITE)
+		file.store_string("\n".join(recent_files))
+		file.close()

--- a/core/main.gd
+++ b/core/main.gd
@@ -103,12 +103,7 @@ func _handle_settings() -> void:
 func append_to_recent_files(file_path: String) -> void:
 	var file: FileAccess
 	var files: String
-	if FileAccess.file_exists(SLib.globalize_path(FileDatabase.RECENT_FILES_DATA)):
-		file = FileAccess.open(SLib.globalize_path(FileDatabase.RECENT_FILES_DATA), FileAccess.READ)
-		files = file.get_as_text()
-		file.close()
-	else:
-		files = ""
+	files = FileAccess.get_file_as_string(FileDatabase.RECENT_FILES_DATA)
 
 	file = FileAccess.open(FileDatabase.RECENT_FILES_DATA, FileAccess.WRITE)
 	file.store_string(file_path + "\n" + files)
@@ -357,9 +352,7 @@ func _reload_recent_files() -> void:
 
 	# Load recent files
 	if FileAccess.file_exists(SLib.globalize_path(FileDatabase.RECENT_FILES_DATA)):
-		var file_access = FileAccess.open(FileDatabase.RECENT_FILES_DATA, FileAccess.READ)
-		var recent_files_list = file_access.get_as_text().split("\n", false)
-		file_access.close()
+		var recent_files_list = FileAccess.get_file_as_string(FileDatabase.RECENT_FILES_DATA).split("\n", false)
 
 		recent_files_list = SLib.merge_unique(recent_files_list, []) # Remove repeated items
 

--- a/core/scripts/editor_api.gd
+++ b/core/scripts/editor_api.gd
@@ -111,6 +111,7 @@ func save_file(file_path: String) -> void:
 					Global.send_notification(Global.Notification.ERROR, "Failed to open file!", "Save in {0} failed with error code {1}".format([file_path, FileAccess.get_open_error()]))
 					return
 				file.store_string(Global.get_editor_text())
+				Global.get_core().append_to_recent_files(file_path)
 				file.close()
 
 				Signals.check_options.emit()
@@ -154,6 +155,7 @@ func load_file(file_path: String) -> void:
 				_unload_current_mode()
 
 				Global.set_editor_text(FileAccess.get_file_as_string(file_path))
+				Global.get_core().append_to_recent_files(file_path)
 				Global.set_editor_disabled(false)
 				if FileAccess.get_open_error():
 					Global.send_notification(Global.Notification.ERROR, "Error in opening file!", "Load from {0} completed with error code {1}".format([file_path, FileAccess.get_open_error()]))
@@ -408,6 +410,7 @@ func _handle_save_file(file_path: String) -> void:
 		return
 
 	file.store_buffer(mode_script._string_to_buffer(Global.get_editor_text()))
+	Global.get_core().append_to_recent_files(file_path)
 	file.close()
 	Signals.check_options.emit()
 
@@ -428,6 +431,7 @@ func _handle_load_file(file_path: String) -> void:
 		return
 
 	Global.set_editor_text(mode_script._buffer_to_string(buffer))
+	Global.get_core().append_to_recent_files(file_path)
 	Global.set_editor_disabled(false)
 	Signals.check_options.emit()
 


### PR DESCRIPTION
<!--Provide a succinct and descriptive title for the pull request, e.g., "Improve caching mechanism for API calls"-->

## Type of Change
<!--Remove unrelated items-->
- New feature

## Description
<!--Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.-->
Previously, a saved file was not added to recent files, so you had to open a new file once after creating and saving it to be visible in the **recent files** menu.

New calls are added to `Core.append_to_recent_files()` after loading and saving a file, and the similar function in the open action script and its call have been removed; all calls are made in `EditorAPI` from now.

## Testing
<!--Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.-->
Works fine with open, save and other related action.

## Impact
<!--Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.-->
There is no important impact, just these:
- Less code in `recent_files` action scrip **+**
- Use `FileAccess.get_file_as_string()` in `append_to_recent_files()` and `_reload_recent_files()` in `Core` instead of custom load **+**
- New call for `Core.append_to_recent_files()` during save **-**

## Additional Information
<!--Any additional information that reviewers should be aware of.-->
Nothing

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings
- [X] Changes were added to CHANGELOG
