### PR TITLE
Restore panel open state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Caret position button ([#96](https://github.com/text-forge/text-forge/pull/96))
 - Add Project module (TFPM): .tfproj support, Project menu, Files panel and Recent Projects ([#95](https://github.com/text-forge/text-forge/pull/95))
 
+### Fixed
+- Restore panel open state ([#103](https://github.com/text-forge/text-forge/pull/103))
+
 ## [v0.1-rc2] - 2025-8-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Preserve editor scroll when text is updated programmatically when `keep_carets` is true ([#101](https://github.com/text-forge/text-forge/pull/101))
 - Error when multiple save requests sent at same time ([#102](https://github.com/text-forge/text-forge/pull/102))
-
-### Fixed
 - Restore panel open state ([#103](https://github.com/text-forge/text-forge/pull/103))
 
 ## [v0.1-rc2] - 2025-8-26

--- a/core/scripts/panel_manager.gd
+++ b/core/scripts/panel_manager.gd
@@ -43,8 +43,6 @@ var data := {
 }
 
 func _ready() -> void:
-	_load_layout()
-
 	for side in 3:
 		# handle panel changing
 		tabs[side].item_selected.connect(_handle_panel.bind(side))
@@ -71,6 +69,7 @@ func _ready() -> void:
 	get_window().close_requested.connect(_save_layout)
 
 	_load_panels()
+	_load_layout()
 
 
 ## Add given [param panel] in [param location] with [param icon], it means new icon in [param location]

--- a/core/scripts/panel_manager.gd
+++ b/core/scripts/panel_manager.gd
@@ -70,6 +70,7 @@ func _ready() -> void:
 
 	_load_panels()
 	_load_layout()
+	_apply_split()
 
 
 ## Add given [param panel] in [param location] with [param icon], it means new icon in [param location]

--- a/core/scripts/panel_manager.gd
+++ b/core/scripts/panel_manager.gd
@@ -117,7 +117,10 @@ func show_panel(location: Panels, index: int) -> void:
 
 ## Saves current panels latout.
 func _save_layout() -> void:
-	Settings.write_data("panels", "layout_data", data)
+	var data_to_save := data.duplicate(true)
+	for l in data_to_save:
+		data_to_save[l]["panels"] = []
+	Settings.write_data("panels", "layout_data", data_to_save)
 
 
 ## Loads panels layout in [member panels]. Will ignore last loaded panels.


### PR DESCRIPTION
<!--Provide a succinct and descriptive title for the pull request, e.g., "Improve caching mechanism for API calls"-->

## Type of Change
<!--Remove unrelated items-->
- Bug fix

## Description
<!--Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.-->
Previously, the ability to save and restore opened panels was designed, but due to the loading of panels after restoration, the editor's state always returned to the first panel. In this change, the panels are loaded first, and then the last state before closing is restored.

## Testing
<!--Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.-->
Works fine for all panels.

## Impact
<!--Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.-->
Nothing

## Additional Information
<!--Any additional information that reviewers should be aware of.-->
Nothing

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings
- [x] Changes were added to CHANGELOG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Panels now consistently restore their open/closed state across sessions, improving layout reliability.

* **Documentation**
  * Changelog updated under “Unreleased” with a “Fixed” entry noting panel state restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->