### PR TITLE
Fix empty mode viewer popup menu at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file. (Notable ch
 The format is based on [Keep a Changelog (1.1)](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning (2.0)](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Fixed
+- Empty *Mode Viewer* popup menu at startup ([#116](https://github.com/text-forge/text-forge/pull/116))
+
 ## [v0.2-beta2] - 2025-10-9
 
 ### Added

--- a/core/scripts/mode_viewer.gd
+++ b/core/scripts/mode_viewer.gd
@@ -2,6 +2,7 @@ extends MenuButton
 
 func _ready() -> void:
 	Signals.mode_changed.connect(_update_mode.unbind(1))
+	_update_mode()
 
 
 func _update_mode() -> void:


### PR DESCRIPTION
<!--Provide a succinct and descriptive title for the pull request, e.g., "Improve caching mechanism for API calls"-->

## Type of Change
<!--Remove unrelated items-->
- Bug fix

## Description
<!--Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.-->
The Mode Viewer includes a popup menu that displays a list of available modes and their corresponding extensions. Prior to this update, this popup menu was empty when the editor was launched (and before the mode was changed).

## Testing
<!--Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.-->
Works fine

## Impact
<!--Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.-->
Nothing

## Additional Information
<!--Any additional information that reviewers should be aware of.-->
Current behavior updates popup menu at mode changing, but we can have more specific trigger.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings
- [x] Changes were added to CHANGELOG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Fixed an issue where the Mode Viewer’s popup menu appeared empty on startup. The menu now initializes correctly and reflects the current mode immediately, so users see the correct options without needing to switch modes or trigger any updates.

* Documentation
  * Added an Unreleased section to the changelog documenting the Mode Viewer startup menu fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->