### PR TITLE
Restore panel split state after startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning (2.0)](https://semver.org/spec/
 
 ### Fixed
 - Empty *Mode Viewer* popup menu at startup ([#116](https://github.com/text-forge/text-forge/pull/116))
+- Panel status is not restored after startup ([#119](https://github.com/text-forge/text-forge/pull/119))
 
 ## [v0.2-beta2] - 2025-10-9
 

--- a/core/scripts/panel_manager.gd
+++ b/core/scripts/panel_manager.gd
@@ -73,7 +73,6 @@ func _ready() -> void:
 
 	_load_panels()
 	_load_layout()
-	_apply_split()
 
 
 ## Add given [param panel] in [param location] with [param icon], it means new icon in [param location]
@@ -159,6 +158,7 @@ func _complete_loading() -> void:
 	for p in _panels:
 		var info := _panels[p]
 		add_panel(info["place"], U.load_resource(p).instantiate(), U.load_resource(S.TEMPLATE_PANEL_ICON.format([info["name"]])))
+	_apply_split()
 	load_completed.emit()
 
 


### PR DESCRIPTION
## Type of Change
<!--Remove unrelated items-->
- Bug fix

## Description
Move `_apply_split()` call after panel loading

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings
- [x] Changes were added to CHANGELOG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Panel status and layout now correctly restore after startup. Previous sessions’ open/closed states and split configurations are reapplied, preventing panels from appearing collapsed, missing, or in the wrong arrangement on launch. This improves reliability and continuity when reopening the app.

* **Documentation**
  * Updated the changelog to include the fix for panel status restoration after startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->