### PR TITLE
Add get_caret_global_draw_pos to editor

### DIFF
--- a/core/scripts/editor.gd
+++ b/core/scripts/editor.gd
@@ -40,7 +40,7 @@ func is_selection_in_line(line: int) -> bool:
 	return false
 
 
-## Returns the caret pixel draw postion in user screen. This is global version of [method TextEdit.get_caret_draw_pos].
+## Returns the caret pixel draw position in user screen. This is global version of [method TextEdit.get_caret_draw_pos].
 ## When [param center] is [code]true[/code] returned position will be in center of caret, otherwise
 ## will be under caret.
 func get_caret_global_draw_pos(caret_index: int = 0, center := false) -> Vector2:

--- a/core/scripts/editor.gd
+++ b/core/scripts/editor.gd
@@ -16,6 +16,7 @@ func _ready() -> void:
 
 	type_timer_timeout.connect(func(): code_completion_requested.emit())
 
+
 ## Returns char index in [param line] and [param column], useful for use original [LineEdit]
 ## functions with [String] options.
 func get_char_index(line: int, column: int) -> int:
@@ -37,6 +38,13 @@ func is_selection_in_line(line: int) -> bool:
 		if line >= selection[0] and line <= selection[1]:
 			return true
 	return false
+
+
+## Returns the caret pixel draw postion in user screen. This is global version of [method TextEdit.get_caret_draw_pos].
+## When [param center] is [code]true[/code] returned position will be in center of caret, otherwise
+## will be under caret.
+func get_caret_global_draw_pos(caret_index: int = 0, center := false) -> Vector2:
+	return get_caret_draw_pos(caret_index) + global_position + Vector2(get_window().position) + Vector2(0, 0.0 if center else get_theme_font_size("font_size") / 2.0)
 
 
 func _on_text_changed() -> void:

--- a/core/scripts/replace_popup.gd
+++ b/core/scripts/replace_popup.gd
@@ -77,7 +77,7 @@ func _show_popup() -> void:
 		_:
 			insert.tooltip_text = "Auto Insert\nThis feature isn't available for this placeholder!"
 			insert.disabled = true
-	popup(Rect2i(Global.get_editor().get_caret_draw_pos() + Global.get_editor().global_position + Vector2(get_tree().get_root().position) + Vector2(0, Settings.get_setting("editor_ui", "font_size")), size))
+	popup(Rect2i(Global.get_editor().get_caret_global_draw_pos(), size))
 	replace.grab_focus()
 	replace.select_all()
 


### PR DESCRIPTION
<!--Provide a succinct and descriptive title for the pull request, e.g., "Improve caching mechanism for API calls"-->

## Type of Change
<!--Remove unrelated items-->
- Refactoring

## Description
<!--Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.-->
Adds a `get_caret_global_draw_pos()` function to editor that returns absolute position of caret in user screen.

## Testing
<!--Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.-->
- [x] Replace panel
- [x] Unit tests

## Impact
<!--Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.-->
Cleaner and safer way to get caret draw position.

## Additional Information
<!--Any additional information that reviewers should be aware of.-->
Nothing

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings
- [x] Changes were added to CHANGELOG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a way to obtain the caret’s pixel position in global screen coordinates, with optional vertical centering based on theme font size.

* **Refactor**
  * Simplified popup positioning by consolidating caret-to-screen coordinate computation into a single unified approach, improving consistency of on-screen placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->