### PR TITLE
Add "UI Filter" for main window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning (2.0)](https://semver.org/spec/
 - Class name declarations to ~40+ files for better type safety ([#139](https://github.com/text-forge/text-forge/pull/139))
 - Security validation for plugin/mod file extraction (prevents path traversal attacks) ([#139](https://github.com/text-forge/text-forge/pull/139))
 - Auto text writing direction for editor ([#144](https://github.com/text-forge/text-forge/pull/144))
+- UI Filter for editor ([#145](https://github.com/text-forge/text-forge/pull/145))
+- Enhanced dynamic reload for settings ([#145](https://github.com/text-forge/text-forge/pull/145))
 
 ### Changed
 - **Action Script:** ~Command > Command Pallete~ to Command > Command Palette (renamed, improved search) ([#139](https://github.com/text-forge/text-forge/pull/139))

--- a/action_scripts/scenes/marketplace.gd
+++ b/action_scripts/scenes/marketplace.gd
@@ -261,7 +261,6 @@ func _complete_installation(
 
 func _change_theme(t_name: String) -> void:
 	Settings.set_setting("editor_ui", "theme_name", t_name)
-	Signals.settings_changed.emit()
 
 
 func _add_image(result: int, response_code: int, __: PackedStringArray, body: PackedByteArray) -> void:

--- a/action_scripts/scenes/preferences.gd
+++ b/action_scripts/scenes/preferences.gd
@@ -9,11 +9,6 @@ extends Window
 ## Tree for section changing.
 @export var tree: Tree
 
-func _on_close_requested() -> void:
-	Signals.settings_changed.emit()
-	queue_free()
-
-
 func _ready() -> void:
 	var config := ConfigFile.new()
 	config.load(S.globalize_path(Settings.PRESETS_FILE))

--- a/action_scripts/scenes/preferences.tscn
+++ b/action_scripts/scenes/preferences.tscn
@@ -37,5 +37,5 @@ size_flags_horizontal = 3
 theme_type_variation = &"PreferencesSectionTab"
 tabs_visible = false
 
-[connection signal="close_requested" from="." to="." method="_on_close_requested"]
+[connection signal="close_requested" from="." to="." method="queue_free"]
 [connection signal="item_selected" from="Margin/HSplit/Tree" to="." method="_on_tree_item_selected"]

--- a/action_scripts/scenes/setting_option.gd
+++ b/action_scripts/scenes/setting_option.gd
@@ -24,7 +24,7 @@ func _ready() -> void:
 			options.current_tab = 0
 			options.get_child(0).button_pressed = value
 			if not value: options.get_child(0).text = "Off"
-		TYPE_INT, TYPE_FLOAT:
+		TYPE_INT:
 			options.current_tab = 1
 			options.get_child(1).value = value
 		TYPE_STRING:
@@ -33,6 +33,9 @@ func _ready() -> void:
 		TYPE_ARRAY:
 			options.current_tab = 3
 			options.get_child(3).text = ", ".join(value.map(func(item): return str(item)))
+		TYPE_FLOAT:
+			options.current_tab = 4
+			options.get_child(4).value = value
 		_:
 			Global.send_notification(
 				Global.Notification.ERROR,
@@ -62,4 +65,9 @@ func _on_line_edit_text_submitted(new_text: String) -> void:
 
 func _on_line_edit_2_text_submitted(new_text: String) -> void:
 	value = Array(new_text.split(",")).map(func(item: String): return item.strip_edges())
+	Settings.set_setting(section, key, value)
+
+
+func _on_spin_box_2_value_changed() -> void:
+	value = options.get_child(4).value
 	Settings.set_setting(section, key, value)

--- a/action_scripts/scenes/setting_option.gd
+++ b/action_scripts/scenes/setting_option.gd
@@ -11,20 +11,20 @@ extends HBoxContainer
 var section: String
 ## Option key.
 var key: String
-## Default value.
-var default = null
 ## Current value.
 var value
 
 func _ready() -> void:
+	if section.is_empty() or key.is_empty():
+		return
 	label.text = key.capitalize()
-	value = Settings.get_setting(section, key, default)
+	value = Settings.get_setting(section, key)
 	match typeof(value):
 		TYPE_BOOL:
 			options.current_tab = 0
 			options.get_child(0).button_pressed = value
 			if not value: options.get_child(0).text = "Off"
-		TYPE_INT:
+		TYPE_INT, TYPE_FLOAT:
 			options.current_tab = 1
 			options.get_child(1).value = value
 		TYPE_STRING:
@@ -33,9 +33,6 @@ func _ready() -> void:
 		TYPE_ARRAY:
 			options.current_tab = 3
 			options.get_child(3).text = ", ".join(value.map(func(item): return str(item)))
-		TYPE_FLOAT:
-			options.current_tab = 4
-			options.get_child(4).value = value
 		_:
 			Global.send_notification(
 				Global.Notification.ERROR,
@@ -65,9 +62,4 @@ func _on_line_edit_text_submitted(new_text: String) -> void:
 
 func _on_line_edit_2_text_submitted(new_text: String) -> void:
 	value = Array(new_text.split(",")).map(func(item: String): return item.strip_edges())
-	Settings.set_setting(section, key, value)
-
-
-func _on_spin_box_2_value_changed() -> void:
-	value = options.get_child(4).value
 	Settings.set_setting(section, key, value)

--- a/action_scripts/scenes/setting_option.tscn
+++ b/action_scripts/scenes/setting_option.tscn
@@ -81,9 +81,18 @@ placeholder_text = "Comma Separated Value (Array)"
 alignment = 1
 metadata/_tab_index = 3
 
+[node name="SpinBox2" type="SpinBox" parent="Margin/HBox/TabContainer"]
+visible = false
+layout_mode = 2
+step = 0.01
+allow_greater = true
+allow_lesser = true
+metadata/_tab_index = 4
+
 [connection signal="pressed" from="Margin/HBox/TabContainer/CheckBox" to="." method="_on_check_box_pressed"]
 [connection signal="value_changed" from="Margin/HBox/TabContainer/SpinBox" to="." method="_on_spin_box_value_changed" unbinds=1]
 [connection signal="text_changed" from="Margin/HBox/TabContainer/LineEdit" to="." method="_on_line_edit_text_submitted"]
 [connection signal="text_submitted" from="Margin/HBox/TabContainer/LineEdit" to="." method="_on_line_edit_text_submitted"]
 [connection signal="text_changed" from="Margin/HBox/TabContainer/LineEdit2" to="." method="_on_line_edit_2_text_submitted"]
 [connection signal="text_submitted" from="Margin/HBox/TabContainer/LineEdit2" to="." method="_on_line_edit_2_text_submitted"]
+[connection signal="value_changed" from="Margin/HBox/TabContainer/SpinBox2" to="." method="_on_spin_box_2_value_changed" unbinds=1]

--- a/action_scripts/scenes/setting_option.tscn
+++ b/action_scripts/scenes/setting_option.tscn
@@ -64,6 +64,7 @@ metadata/_tab_index = 0
 visible = false
 layout_mode = 2
 theme_type_variation = &"SettingsOptionSpinBox"
+step = 0.01
 allow_greater = true
 allow_lesser = true
 alignment = 1
@@ -81,18 +82,9 @@ placeholder_text = "Comma Separated Value (Array)"
 alignment = 1
 metadata/_tab_index = 3
 
-[node name="SpinBox2" type="SpinBox" parent="Margin/HBox/TabContainer"]
-visible = false
-layout_mode = 2
-step = 0.01
-allow_greater = true
-allow_lesser = true
-metadata/_tab_index = 4
-
 [connection signal="pressed" from="Margin/HBox/TabContainer/CheckBox" to="." method="_on_check_box_pressed"]
 [connection signal="value_changed" from="Margin/HBox/TabContainer/SpinBox" to="." method="_on_spin_box_value_changed" unbinds=1]
 [connection signal="text_changed" from="Margin/HBox/TabContainer/LineEdit" to="." method="_on_line_edit_text_submitted"]
 [connection signal="text_submitted" from="Margin/HBox/TabContainer/LineEdit" to="." method="_on_line_edit_text_submitted"]
 [connection signal="text_changed" from="Margin/HBox/TabContainer/LineEdit2" to="." method="_on_line_edit_2_text_submitted"]
 [connection signal="text_submitted" from="Margin/HBox/TabContainer/LineEdit2" to="." method="_on_line_edit_2_text_submitted"]
-[connection signal="value_changed" from="Margin/HBox/TabContainer/SpinBox2" to="." method="_on_spin_box_2_value_changed" unbinds=1]

--- a/addons/gdUnit4/GdUnitRunner.cfg
+++ b/addons/gdUnit4/GdUnitRunner.cfg
@@ -8,7 +8,7 @@
 			"attribute_index": -1,
 			"display_name": "test_action_script_initializes",
 			"fully_qualified_name": "tests.action_scripts.action_scripts_test.test_action_script_initializes",
-			"guid": "1cad64f2-08a4443-4a546bc-319ddb27c7",
+			"guid": "599e360e-2655431-6831cf2-f819606ca8",
 			"line_number": 22,
 			"metadata": {
 
@@ -26,7 +26,7 @@
 			"attribute_index": -1,
 			"display_name": "test_id_property_set",
 			"fully_qualified_name": "tests.action_scripts.action_scripts_test.test_id_property_set",
-			"guid": "970f29aa-38c449c-2b851bd-25817cccf3",
+			"guid": "909c2a3d-89ce4f5-29fef3d-eef78ea06b",
 			"line_number": 26,
 			"metadata": {
 
@@ -44,7 +44,7 @@
 			"attribute_index": -1,
 			"display_name": "test_menu_property_set",
 			"fully_qualified_name": "tests.action_scripts.action_scripts_test.test_menu_property_set",
-			"guid": "fb9f0a60-efaf453-38a1b29-ff426ad29e",
+			"guid": "734ad00d-c0e8432-38398e0-5c5cced73e",
 			"line_number": 29,
 			"metadata": {
 
@@ -62,7 +62,7 @@
 			"attribute_index": -1,
 			"display_name": "test_requires_file_default_false",
 			"fully_qualified_name": "tests.action_scripts.action_scripts_test.test_requires_file_default_false",
-			"guid": "5705c3c3-04bf4d2-f8d1f4a-9e0471d401",
+			"guid": "41156150-02ca479-3aeeba3-9650a6375c",
 			"line_number": 32,
 			"metadata": {
 
@@ -80,7 +80,7 @@
 			"attribute_index": -1,
 			"display_name": "test_requires_saved_file_default_false",
 			"fully_qualified_name": "tests.action_scripts.action_scripts_test.test_requires_saved_file_default_false",
-			"guid": "73e90ebc-f8a149e-ebc9a32-ac7b0a19b4",
+			"guid": "bb9c7530-7ed44be-284bc0b-288cef663a",
 			"line_number": 35,
 			"metadata": {
 
@@ -98,7 +98,7 @@
 			"attribute_index": -1,
 			"display_name": "test_enable_default_true",
 			"fully_qualified_name": "tests.action_scripts.action_scripts_test.test_enable_default_true",
-			"guid": "c83e2315-3f9d497-08d87b5-68d953c63b",
+			"guid": "7ab8c95a-c7d7495-58e41aa-62fd6650ab",
 			"line_number": 38,
 			"metadata": {
 
@@ -116,7 +116,7 @@
 			"attribute_index": -1,
 			"display_name": "test_action_shortcut_exists",
 			"fully_qualified_name": "tests.action_scripts.action_scripts_test.test_action_shortcut_exists",
-			"guid": "a7994851-6f9a41a-3a2a328-13fa653566",
+			"guid": "656f6d61-f49f43c-e9f0442-eaadcdffd0",
 			"line_number": 41,
 			"metadata": {
 
@@ -134,7 +134,7 @@
 			"attribute_index": -1,
 			"display_name": "test_is_enable_returns_enable_state",
 			"fully_qualified_name": "tests.action_scripts.action_scripts_test.test_is_enable_returns_enable_state",
-			"guid": "d6565075-b2c9441-e98ef4e-074b520b62",
+			"guid": "59ad0437-b17d423-98d74e2-b7b8428533",
 			"line_number": 45,
 			"metadata": {
 
@@ -152,7 +152,7 @@
 			"attribute_index": -1,
 			"display_name": "test_check_option_extra_default_true",
 			"fully_qualified_name": "tests.action_scripts.action_scripts_test.test_check_option_extra_default_true",
-			"guid": "b547e14f-9892496-1a7df07-fe20f4d347",
+			"guid": "ee0aa76c-58884f7-e8fbd1d-79fa1d94db",
 			"line_number": 51,
 			"metadata": {
 
@@ -170,7 +170,7 @@
 			"attribute_index": -1,
 			"display_name": "test_check_option_no_requirements",
 			"fully_qualified_name": "tests.action_scripts.action_scripts_test.test_check_option_no_requirements",
-			"guid": "f3fb1e90-a486479-f92744d-946cebd5f8",
+			"guid": "344384ba-51784d8-88a10ec-db1a497975",
 			"line_number": 55,
 			"metadata": {
 
@@ -188,7 +188,7 @@
 			"attribute_index": -1,
 			"display_name": "test_check_option_requires_file_enabled",
 			"fully_qualified_name": "tests.action_scripts.action_scripts_test.test_check_option_requires_file_enabled",
-			"guid": "af458e99-1acd46c-ebe4ecf-bb2055bb18",
+			"guid": "f9bd09e9-591c49c-695b192-c86101c5a7",
 			"line_number": 61,
 			"metadata": {
 
@@ -206,8 +206,8 @@
 			"attribute_index": -1,
 			"display_name": "test_check_option_requires_file_disabled",
 			"fully_qualified_name": "tests.action_scripts.action_scripts_test.test_check_option_requires_file_disabled",
-			"guid": "129880a6-81e14cf-58df33d-355b1e4ba8",
-			"line_number": 67,
+			"guid": "0f9319d6-4aaa41c-ba78be0-03826cca69",
+			"line_number": 69,
 			"metadata": {
 
 			},
@@ -224,8 +224,8 @@
 			"attribute_index": -1,
 			"display_name": "test_enable_setter_updates_menu_state",
 			"fully_qualified_name": "tests.action_scripts.action_scripts_test.test_enable_setter_updates_menu_state",
-			"guid": "95f335ce-849945e-097109c-2eeb855fd8",
-			"line_number": 75,
+			"guid": "dcbc5d0d-186b44e-094da83-f2307006a3",
+			"line_number": 77,
 			"metadata": {
 
 			},
@@ -242,8 +242,8 @@
 			"attribute_index": -1,
 			"display_name": "test_enable_setter_enables_menu_item",
 			"fully_qualified_name": "tests.action_scripts.action_scripts_test.test_enable_setter_enables_menu_item",
-			"guid": "66b6ba24-8e0347c-49819d9-0357e2afc0",
-			"line_number": 81,
+			"guid": "f234076c-aa5b48f-6bcfaa5-32df1ea2dc",
+			"line_number": 83,
 			"metadata": {
 
 			},
@@ -260,8 +260,8 @@
 			"attribute_index": -1,
 			"display_name": "test_action_scripts",
 			"fully_qualified_name": "tests.action_scripts.action_scripts_test.test_action_scripts",
-			"guid": "c4e84022-ed5741c-8b58771-f4ba8fd314",
-			"line_number": 88,
+			"guid": "06f7d9e5-32ce4b4-db1dcc5-f370627afb",
+			"line_number": 90,
 			"metadata": {
 
 			},
@@ -278,7 +278,7 @@
 			"attribute_index": -1,
 			"display_name": "test_initialize_sets_requires_file",
 			"fully_qualified_name": "tests.action_scripts.close_test.test_initialize_sets_requires_file",
-			"guid": "bc9ae0b8-be1849b-296615d-eef9ab8b5a",
+			"guid": "00993d86-1a9a493-b89321b-105a0f1252",
 			"line_number": 21,
 			"metadata": {
 
@@ -296,7 +296,7 @@
 			"attribute_index": -1,
 			"display_name": "test_initialize_connects_to_close_file_signal",
 			"fully_qualified_name": "tests.action_scripts.close_test.test_initialize_connects_to_close_file_signal",
-			"guid": "db5a63b6-bf64494-caee2d2-a53228dd92",
+			"guid": "821da754-6ed84cc-a910d04-f931799a32",
 			"line_number": 25,
 			"metadata": {
 
@@ -314,7 +314,7 @@
 			"attribute_index": -1,
 			"display_name": "test_script_extends_action_script",
 			"fully_qualified_name": "tests.action_scripts.close_test.test_script_extends_action_script",
-			"guid": "7323b2d8-39b7488-89a53a5-3e2e79f63d",
+			"guid": "3f972a32-7f97413-1b1b29e-fc88db9574",
 			"line_number": 36,
 			"metadata": {
 
@@ -332,7 +332,7 @@
 			"attribute_index": -1,
 			"display_name": "test_run_action_callable_exists",
 			"fully_qualified_name": "tests.action_scripts.close_test.test_run_action_callable_exists",
-			"guid": "382a0e8a-131e4e2-48be4a4-bbd63f8a05",
+			"guid": "f9cf9f40-92b144c-a8f8857-9628c30b5f",
 			"line_number": 39,
 			"metadata": {
 
@@ -348,9 +348,603 @@
 			"@subpath": "",
 			"assembly_location": "",
 			"attribute_index": -1,
+			"display_name": "test_change_theme_updates_setting",
+			"fully_qualified_name": "tests.action_scripts.scenes.marketplace_test.test_change_theme_updates_setting",
+			"guid": "b8c5d551-fc9a402-8a81adb-7acca5169a",
+			"line_number": 26,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/marketplace_test.gd",
+			"suite_name": "marketplace_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/marketplace_test.gd",
+			"test_name": "test_change_theme_updates_setting"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_change_theme_triggers_settings_changed_signal",
+			"fully_qualified_name": "tests.action_scripts.scenes.marketplace_test.test_change_theme_triggers_settings_changed_signal",
+			"guid": "ef454636-823e40f-f9247be-e3ca20d481",
+			"line_number": 39,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/marketplace_test.gd",
+			"suite_name": "marketplace_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/marketplace_test.gd",
+			"test_name": "test_change_theme_triggers_settings_changed_signal"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_change_theme_no_duplicate_signal",
+			"fully_qualified_name": "tests.action_scripts.scenes.marketplace_test.test_change_theme_no_duplicate_signal",
+			"guid": "e20d9f5d-9c264f8-dad3189-b29dc5e7ae",
+			"line_number": 57,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/marketplace_test.gd",
+			"suite_name": "marketplace_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/marketplace_test.gd",
+			"test_name": "test_change_theme_no_duplicate_signal"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_settings_api_handles_theme_change",
+			"fully_qualified_name": "tests.action_scripts.scenes.marketplace_test.test_settings_api_handles_theme_change",
+			"guid": "dfd102b0-54f7470-f941913-779e29beb7",
+			"line_number": 75,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/marketplace_test.gd",
+			"suite_name": "marketplace_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/marketplace_test.gd",
+			"test_name": "test_settings_api_handles_theme_change"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_theme_setting_with_same_value_no_signal",
+			"fully_qualified_name": "tests.action_scripts.scenes.marketplace_test.test_theme_setting_with_same_value_no_signal",
+			"guid": "365d0292-68f3405-09c28ac-73efb971c7",
+			"line_number": 86,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/marketplace_test.gd",
+			"suite_name": "marketplace_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/marketplace_test.gd",
+			"test_name": "test_theme_setting_with_same_value_no_signal"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_preferences_window_initializes",
+			"fully_qualified_name": "tests.action_scripts.scenes.preferences_test.test_preferences_window_initializes",
+			"guid": "6dde9927-44e1409-7b6a155-fee7bac2b5",
+			"line_number": 18,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"suite_name": "preferences_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"test_name": "test_preferences_window_initializes"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_container_exists",
+			"fully_qualified_name": "tests.action_scripts.scenes.preferences_test.test_container_exists",
+			"guid": "38f8d954-4ba94be-fa16ca0-ee01a9c944",
+			"line_number": 22,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"suite_name": "preferences_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"test_name": "test_container_exists"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_tree_exists",
+			"fully_qualified_name": "tests.action_scripts.scenes.preferences_test.test_tree_exists",
+			"guid": "38063f5f-3f534a4-5b9e58b-22ff9756e8",
+			"line_number": 26,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"suite_name": "preferences_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"test_name": "test_tree_exists"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_close_requested_signal_connected",
+			"fully_qualified_name": "tests.action_scripts.scenes.preferences_test.test_close_requested_signal_connected",
+			"guid": "1edd40c6-ff30440-68e2bc4-4a2c7cc265",
+			"line_number": 30,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"suite_name": "preferences_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"test_name": "test_close_requested_signal_connected"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_preferences_window_no_manual_signal_emission",
+			"fully_qualified_name": "tests.action_scripts.scenes.preferences_test.test_preferences_window_no_manual_signal_emission",
+			"guid": "81ddbc0f-bbcb41c-7a1567b-62b32a2eae",
+			"line_number": 40,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"suite_name": "preferences_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"test_name": "test_preferences_window_no_manual_signal_emission"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_preferences_loads_settings_from_presets",
+			"fully_qualified_name": "tests.action_scripts.scenes.preferences_test.test_preferences_loads_settings_from_presets",
+			"guid": "85a9c866-f61b4eb-f821775-56d6e99284",
+			"line_number": 54,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"suite_name": "preferences_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"test_name": "test_preferences_loads_settings_from_presets"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_setting_sections_created",
+			"fully_qualified_name": "tests.action_scripts.scenes.preferences_test.test_setting_sections_created",
+			"guid": "3f7440ba-4c7a424-b953777-1eee8c0b62",
+			"line_number": 62,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"suite_name": "preferences_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"test_name": "test_setting_sections_created"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_empty_sections_removed",
+			"fully_qualified_name": "tests.action_scripts.scenes.preferences_test.test_empty_sections_removed",
+			"guid": "1e9a78da-5cac48e-fac6aea-6fb611f12d",
+			"line_number": 71,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"suite_name": "preferences_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"test_name": "test_empty_sections_removed"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_section_names_capitalized",
+			"fully_qualified_name": "tests.action_scripts.scenes.preferences_test.test_section_names_capitalized",
+			"guid": "69468269-9a4d470-98351e3-61d4e3cc44",
+			"line_number": 84,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"suite_name": "preferences_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/preferences_test.gd",
+			"test_name": "test_section_names_capitalized"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_setting_option_initializes",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_setting_option_initializes",
+			"guid": "d0674571-d6e2493-b87e7de-0d4307c43a",
+			"line_number": 32,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_setting_option_initializes"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_label_exists",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_label_exists",
+			"guid": "4af80c90-bd2f408-0944801-5f53a1c182",
+			"line_number": 36,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_label_exists"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_options_tab_container_exists",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_options_tab_container_exists",
+			"guid": "4c94a6a3-0f7a4b4-185df60-f18f5c61e0",
+			"line_number": 40,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_options_tab_container_exists"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_bool_setting_displays_correctly",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_bool_setting_displays_correctly",
+			"guid": "d7f14fcb-fcf6496-191a196-d4184d3395",
+			"line_number": 44,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_bool_setting_displays_correctly"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_bool_setting_false_displays_off",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_bool_setting_false_displays_off",
+			"guid": "b7b6685f-33e7467-5af11c5-3a1598dc53",
+			"line_number": 54,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_bool_setting_false_displays_off"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_int_setting_displays_correctly",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_int_setting_displays_correctly",
+			"guid": "773da9cf-30474ae-689f318-a55d8b180a",
+			"line_number": 64,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_int_setting_displays_correctly"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_float_setting_displays_correctly",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_float_setting_displays_correctly",
+			"guid": "a8abb158-5c564e1-4a65e7a-69ced5720f",
+			"line_number": 74,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_float_setting_displays_correctly"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_float_setting_with_zero",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_float_setting_with_zero",
+			"guid": "e661bbfe-1947477-29de0f9-54b51e59a9",
+			"line_number": 84,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_float_setting_with_zero"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_float_setting_with_negative_value",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_float_setting_with_negative_value",
+			"guid": "a8d30bc3-fd3c499-7b72bd3-9f793090a8",
+			"line_number": 93,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_float_setting_with_negative_value"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_float_setting_with_large_value",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_float_setting_with_large_value",
+			"guid": "68734d6a-60fd430-581de26-08b4e2a6e1",
+			"line_number": 102,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_float_setting_with_large_value"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_string_setting_displays_correctly",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_string_setting_displays_correctly",
+			"guid": "05e5400a-287d45a-5a20e45-191390bc89",
+			"line_number": 111,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_string_setting_displays_correctly"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_array_setting_displays_correctly",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_array_setting_displays_correctly",
+			"guid": "f79d4796-abaa431-5ba4e6b-7cd4774577",
+			"line_number": 121,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_array_setting_displays_correctly"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_label_text_capitalized",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_label_text_capitalized",
+			"guid": "dd42b532-7e89467-cb6257b-50aafa8c4a",
+			"line_number": 131,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_label_text_capitalized"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_checkbox_toggle_updates_setting",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_checkbox_toggle_updates_setting",
+			"guid": "85dc3245-dfde489-984ea04-7ef340d45c",
+			"line_number": 139,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_checkbox_toggle_updates_setting"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_spinbox_change_updates_int_setting",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_spinbox_change_updates_int_setting",
+			"guid": "78b8f836-22b34d2-09a90db-ffc2b4ea94",
+			"line_number": 152,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_spinbox_change_updates_int_setting"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_line_edit_change_updates_string_setting",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_line_edit_change_updates_string_setting",
+			"guid": "9a7662b8-06f0488-9a73f03-c4db1ee8c4",
+			"line_number": 164,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_line_edit_change_updates_string_setting"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_line_edit2_change_updates_array_setting",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_line_edit2_change_updates_array_setting",
+			"guid": "2e8d09d6-4e99482-8b777a2-9021dbc410",
+			"line_number": 175,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_line_edit2_change_updates_array_setting"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_array_setting_strips_whitespace",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_array_setting_strips_whitespace",
+			"guid": "4e3d85d7-664547b-8a81ee3-a93fdc1f8a",
+			"line_number": 187,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_array_setting_strips_whitespace"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_invalid_type_queues_free",
+			"fully_qualified_name": "tests.action_scripts.scenes.setting_option_test.test_invalid_type_queues_free",
+			"guid": "7246463d-9a4b41b-6939611-03e8d44565",
+			"line_number": 199,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"suite_name": "setting_option_test",
+			"suite_resource_path": "res://tests/action_scripts/scenes/setting_option_test.gd",
+			"test_name": "test_invalid_type_queues_free"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
 			"display_name": "test_backup_saved_signal_exists",
 			"fully_qualified_name": "tests.core.autoload.backup_core_test.test_backup_saved_signal_exists",
-			"guid": "da530d63-50a8490-3a529e2-1ebdbb2f97",
+			"guid": "da02a2e7-71cf4ec-9b8cefa-3c5e860d11",
 			"line_number": 12,
 			"metadata": {
 
@@ -368,7 +962,7 @@
 			"attribute_index": -1,
 			"display_name": "test_backup_failed_signal_exists",
 			"fully_qualified_name": "tests.core.autoload.backup_core_test.test_backup_failed_signal_exists",
-			"guid": "fbc10a5c-cfbe469-ba63c65-612e2915aa",
+			"guid": "d81718e2-3a9742b-8adbdc6-540edd6c66",
 			"line_number": 15,
 			"metadata": {
 
@@ -386,7 +980,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_backups_list_returns_dictionary",
 			"fully_qualified_name": "tests.core.autoload.backup_core_test.test_get_backups_list_returns_dictionary",
-			"guid": "582558cc-209e422-f926f7e-e3db33123d",
+			"guid": "df790dbb-b995481-280f56e-041156e13c",
 			"line_number": 18,
 			"metadata": {
 
@@ -404,7 +998,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_backups_list_empty_when_no_backups",
 			"fully_qualified_name": "tests.core.autoload.backup_core_test.test_get_backups_list_empty_when_no_backups",
-			"guid": "347a0a6d-396d40b-bab800d-1598138366",
+			"guid": "b217555f-9a9741c-39f4ae9-d9e8978492",
 			"line_number": 22,
 			"metadata": {
 
@@ -422,7 +1016,7 @@
 			"attribute_index": -1,
 			"display_name": "test_generate_new_backup_id_returns_string",
 			"fully_qualified_name": "tests.core.autoload.backup_core_test.test_generate_new_backup_id_returns_string",
-			"guid": "cec7bd3a-db7640c-996b527-5fac7caf41",
+			"guid": "fee67127-9b9541a-b95e6a0-29195005c1",
 			"line_number": 29,
 			"metadata": {
 
@@ -440,7 +1034,7 @@
 			"attribute_index": -1,
 			"display_name": "test_generate_new_backup_id_unique",
 			"fully_qualified_name": "tests.core.autoload.backup_core_test.test_generate_new_backup_id_unique",
-			"guid": "144cbc72-f76b4f7-f9cc20d-10faec65ef",
+			"guid": "4a449d7a-d158432-babb8c5-5fff2e81d7",
 			"line_number": 34,
 			"metadata": {
 
@@ -458,7 +1052,7 @@
 			"attribute_index": -1,
 			"display_name": "test_generate_new_backup_id_format",
 			"fully_qualified_name": "tests.core.autoload.backup_core_test.test_generate_new_backup_id_format",
-			"guid": "704724d2-f781458-6920b58-5d6696698a",
+			"guid": "9d64a52d-a2ef405-8a5383e-f7afd43d67",
 			"line_number": 40,
 			"metadata": {
 
@@ -476,7 +1070,7 @@
 			"attribute_index": -1,
 			"display_name": "test_backup_file_without_open_file",
 			"fully_qualified_name": "tests.core.autoload.backup_core_test.test_backup_file_without_open_file",
-			"guid": "df993ea3-036c486-79cafff-d2008f97e5",
+			"guid": "ef4af1c1-684f4c7-2bdef4e-0c7f2de12e",
 			"line_number": 46,
 			"metadata": {
 
@@ -494,7 +1088,7 @@
 			"attribute_index": -1,
 			"display_name": "test_restore_backup_nonexistent_code",
 			"fully_qualified_name": "tests.core.autoload.backup_core_test.test_restore_backup_nonexistent_code",
-			"guid": "2600bf1d-e507423-6ba4ec3-6474e04ba2",
+			"guid": "0f9dfdab-1e6f4f0-3a0132d-a4acc7cd5a",
 			"line_number": 60,
 			"metadata": {
 
@@ -512,7 +1106,7 @@
 			"attribute_index": -1,
 			"display_name": "test_convert_to_days_handles_datetime_string",
 			"fully_qualified_name": "tests.core.autoload.backup_core_test.test_convert_to_days_handles_datetime_string",
-			"guid": "d65318da-8045408-f8a95be-3b338ea065",
+			"guid": "78aaa315-b683452-7a72349-eba8721d65",
 			"line_number": 64,
 			"metadata": {
 
@@ -530,7 +1124,7 @@
 			"attribute_index": -1,
 			"display_name": "test_settings_presets_defined",
 			"fully_qualified_name": "tests.core.autoload.backup_core_test.test_settings_presets_defined",
-			"guid": "502fbda8-ae92488-6a17917-3a596bb908",
+			"guid": "039dc628-673e452-2892e06-bb8062c054",
 			"line_number": 70,
 			"metadata": {
 
@@ -548,7 +1142,7 @@
 			"attribute_index": -1,
 			"display_name": "test_auto_backup_default_enabled",
 			"fully_qualified_name": "tests.core.autoload.backup_core_test.test_auto_backup_default_enabled",
-			"guid": "cd8f235e-c6544d2-5a1e2ab-72d346e9b5",
+			"guid": "29be0d43-37764f0-7984325-d2c64a36e6",
 			"line_number": 76,
 			"metadata": {
 
@@ -566,7 +1160,7 @@
 			"attribute_index": -1,
 			"display_name": "test_backup_interval_default_value",
 			"fully_qualified_name": "tests.core.autoload.backup_core_test.test_backup_interval_default_value",
-			"guid": "aa31c189-8efd4db-d80b8b3-1e6a574758",
+			"guid": "a6a64fe7-901e4a2-9a4ac7c-4a877130ef",
 			"line_number": 80,
 			"metadata": {
 
@@ -584,7 +1178,7 @@
 			"attribute_index": -1,
 			"display_name": "test_keep_backup_days_default_value",
 			"fully_qualified_name": "tests.core.autoload.backup_core_test.test_keep_backup_days_default_value",
-			"guid": "a2330473-661b46a-e91c13d-efb60344c7",
+			"guid": "fd2d9e0b-77c3492-2a9af63-c70b71432d",
 			"line_number": 84,
 			"metadata": {
 
@@ -602,7 +1196,7 @@
 			"attribute_index": 0,
 			"display_name": "test_confirmation_dialog:0 ('Anything', 'Anything', 'Anything', 'Anything', null::null, null::null, true)",
 			"fully_qualified_name": "tests.core.autoload.factory_test.test_confirmation_dialog.test_confirmation_dialog:0 ('Anything', 'Anything', 'Anything', 'Anything', null::null, null::null, true)",
-			"guid": "51f24e9a-f2c0479-5bf50d9-c6b70901ec",
+			"guid": "c6464690-5e8249a-b98a5f2-362f1b74d6",
 			"line_number": 30,
 			"metadata": {
 
@@ -620,7 +1214,7 @@
 			"attribute_index": 1,
 			"display_name": "test_confirmation_dialog:1 ('Anything', 'Anything', 'Anything', 'Anything', null::null, null::null, false)",
 			"fully_qualified_name": "tests.core.autoload.factory_test.test_confirmation_dialog.test_confirmation_dialog:1 ('Anything', 'Anything', 'Anything', 'Anything', null::null, null::null, false)",
-			"guid": "ca5440ed-093145f-0ba1719-755001aa9b",
+			"guid": "bbbbba3b-239c469-89a6517-a5699fdb06",
 			"line_number": 30,
 			"metadata": {
 
@@ -638,7 +1232,7 @@
 			"attribute_index": 0,
 			"display_name": "test_single_line_input:0 ('', '', null::null, true)",
 			"fully_qualified_name": "tests.core.autoload.factory_test.test_single_line_input.test_single_line_input:0 ('', '', null::null, true)",
-			"guid": "8eafa687-a95142c-9805a7e-3c014af40b",
+			"guid": "41f24a9c-6254457-ba02c92-5296500398",
 			"line_number": 38,
 			"metadata": {
 
@@ -656,7 +1250,7 @@
 			"attribute_index": 1,
 			"display_name": "test_single_line_input:1 ('', '', null::null, false)",
 			"fully_qualified_name": "tests.core.autoload.factory_test.test_single_line_input.test_single_line_input:1 ('', '', null::null, false)",
-			"guid": "0037c0d9-4fa94fd-5ac72cc-ce0b90fc2a",
+			"guid": "7a1f60f2-8fd04ea-6867cf8-8b0bcd7255",
 			"line_number": 38,
 			"metadata": {
 
@@ -674,7 +1268,7 @@
 			"attribute_index": -1,
 			"display_name": "test_notification_enum_values",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_notification_enum_values",
-			"guid": "2b5fd019-fa484a4-7b0e457-4f7d5ce6df",
+			"guid": "8224f3e0-5d67444-4b47013-f5c08584b0",
 			"line_number": 10,
 			"metadata": {
 
@@ -692,7 +1286,7 @@
 			"attribute_index": -1,
 			"display_name": "test_window_manager_exists",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_window_manager_exists",
-			"guid": "28859330-ee6941b-28eadf3-c0124e8059",
+			"guid": "d96f6705-a4184bd-9a8eaf2-4da47254f5",
 			"line_number": 15,
 			"metadata": {
 
@@ -710,7 +1304,7 @@
 			"attribute_index": -1,
 			"display_name": "test_damaged_modes_is_dictionary",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_damaged_modes_is_dictionary",
-			"guid": "efcabe5d-0800486-68d38a5-33f217f592",
+			"guid": "4b02c9e6-7a4f46a-5851d3c-0701dcf033",
 			"line_number": 19,
 			"metadata": {
 
@@ -728,7 +1322,7 @@
 			"attribute_index": -1,
 			"display_name": "test_shortcut_map_loaded",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_shortcut_map_loaded",
-			"guid": "5668d268-848e422-4ac68de-0de9cd3b9c",
+			"guid": "1c120485-04a24ff-2a3b092-d38c431d27",
 			"line_number": 22,
 			"metadata": {
 
@@ -746,7 +1340,7 @@
 			"attribute_index": -1,
 			"display_name": "test_commands_dictionary_exists",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_commands_dictionary_exists",
-			"guid": "1f1d20fd-a851483-ca2b17f-4fc79109fb",
+			"guid": "835896aa-7bba46f-1b3ceff-d9128500b3",
 			"line_number": 26,
 			"metadata": {
 
@@ -764,7 +1358,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_editor_returns_editor",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_get_editor_returns_editor",
-			"guid": "b22f892a-a9ef4d4-1a0fba7-804456a6fe",
+			"guid": "c2df2aa8-1848498-8add915-364a573c38",
 			"line_number": 30,
 			"metadata": {
 
@@ -782,7 +1376,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_core_returns_core",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_get_core_returns_core",
-			"guid": "ffa2c852-08ba4e1-8bff7c7-89191677e7",
+			"guid": "1f5a5257-d3b3476-4abba85-bd56c2af6a",
 			"line_number": 35,
 			"metadata": {
 
@@ -800,7 +1394,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_editor_api_returns_api",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_get_editor_api_returns_api",
-			"guid": "19ece35d-a433442-7976a07-4449d972ad",
+			"guid": "f9be78fe-51664ca-b8bb1b7-30d3db90cc",
 			"line_number": 40,
 			"metadata": {
 
@@ -818,7 +1412,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_scripts_node_returns_node",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_get_scripts_node_returns_node",
-			"guid": "dccb0199-6f9e45c-688b654-10f2d9561d",
+			"guid": "3b3479e7-9e52437-ebe235e-27525a4f26",
 			"line_number": 45,
 			"metadata": {
 
@@ -836,7 +1430,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_panel_manager_returns_manager",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_get_panel_manager_returns_manager",
-			"guid": "91f20ab7-c52947a-ea019c6-a51445b66a",
+			"guid": "4cca0ebf-943c445-0a5afc1-4ddd08cec8",
 			"line_number": 50,
 			"metadata": {
 
@@ -854,7 +1448,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_file_name_returns_string",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_get_file_name_returns_string",
-			"guid": "616453ed-3f4d4df-1847381-ad5ea66ed7",
+			"guid": "d23f55d8-46ed4b8-4ad7bec-e1ef1fd03b",
 			"line_number": 55,
 			"metadata": {
 
@@ -872,7 +1466,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_file_path_returns_string",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_get_file_path_returns_string",
-			"guid": "d891b140-215e46c-db90a7a-88fb26fd50",
+			"guid": "9a138008-9bd94b3-497dc00-70a279fdbf",
 			"line_number": 59,
 			"metadata": {
 
@@ -890,7 +1484,7 @@
 			"attribute_index": -1,
 			"display_name": "test_set_file_name_updates_name",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_set_file_name_updates_name",
-			"guid": "ddbfe822-d80c47f-285ef52-eefcef8862",
+			"guid": "69dcea0a-34884d9-0b8d3d9-5accce31a4",
 			"line_number": 63,
 			"metadata": {
 
@@ -908,7 +1502,7 @@
 			"attribute_index": -1,
 			"display_name": "test_set_file_path_updates_path",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_set_file_path_updates_path",
-			"guid": "b24f9362-4e344b2-eb7c551-a3fb7bc694",
+			"guid": "a0600336-9ba64a9-897df0a-4cff782872",
 			"line_number": 69,
 			"metadata": {
 
@@ -926,7 +1520,7 @@
 			"attribute_index": -1,
 			"display_name": "test_has_file_checks_absolute_path",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_has_file_checks_absolute_path",
-			"guid": "293df9c6-a4da48b-eb52f9b-57bd951646",
+			"guid": "afc7cee0-894c481-f859b75-14e13ba919",
 			"line_number": 75,
 			"metadata": {
 
@@ -944,7 +1538,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_editor_text_returns_string",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_get_editor_text_returns_string",
-			"guid": "14daf7cf-12c1462-fa93e2a-67498e27b2",
+			"guid": "1d03ef5a-ae45435-dab017e-760e0d943a",
 			"line_number": 83,
 			"metadata": {
 
@@ -962,7 +1556,7 @@
 			"attribute_index": -1,
 			"display_name": "test_set_editor_text_updates_text",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_set_editor_text_updates_text",
-			"guid": "8cc3b174-89a8433-c95e3a8-8d7828e753",
+			"guid": "d552d415-a71f4f1-08e567c-f16c849131",
 			"line_number": 87,
 			"metadata": {
 
@@ -980,7 +1574,7 @@
 			"attribute_index": -1,
 			"display_name": "test_set_editor_disabled_changes_state",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_set_editor_disabled_changes_state",
-			"guid": "f84aa158-0a784dc-8b5a234-7a93644fbb",
+			"guid": "e32aa77b-a8f24cd-985bb0f-c4ac0c2b5e",
 			"line_number": 93,
 			"metadata": {
 
@@ -998,7 +1592,7 @@
 			"attribute_index": -1,
 			"display_name": "test_is_editor_disabled_returns_boolean",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_is_editor_disabled_returns_boolean",
-			"guid": "019d5acf-745a462-9ad4735-bf92e2f5fb",
+			"guid": "b6179999-bc83453-f9c53c4-e5cc48735c",
 			"line_number": 101,
 			"metadata": {
 
@@ -1016,7 +1610,7 @@
 			"attribute_index": -1,
 			"display_name": "test_define_command_adds_command",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_define_command_adds_command",
-			"guid": "676a0899-b1ea41a-9a30151-7efd28c821",
+			"guid": "2c3bd72c-68014b0-7bbbf55-74865d3014",
 			"line_number": 105,
 			"metadata": {
 
@@ -1034,7 +1628,7 @@
 			"attribute_index": -1,
 			"display_name": "test_define_command_stores_shortcut",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_define_command_stores_shortcut",
-			"guid": "8e3de253-6f6d443-5908400-9f8bdce392",
+			"guid": "53e01561-4553440-99752a3-b7613b6d25",
 			"line_number": 110,
 			"metadata": {
 
@@ -1052,7 +1646,7 @@
 			"attribute_index": -1,
 			"display_name": "test_has_unsaved_change_checks_star",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_has_unsaved_change_checks_star",
-			"guid": "bde261af-b8c6443-197e38c-ca4722c344",
+			"guid": "9fe55faf-8c2547b-5912ad7-a826260589",
 			"line_number": 115,
 			"metadata": {
 
@@ -1070,7 +1664,7 @@
 			"attribute_index": -1,
 			"display_name": "test_mark_file_as_unsaved_adds_star",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_mark_file_as_unsaved_adds_star",
-			"guid": "5f5d4cb9-29bf41c-7ac0d5e-80c5e55a52",
+			"guid": "e11312fd-40ca478-1a4bcc1-ddb7c88823",
 			"line_number": 123,
 			"metadata": {
 
@@ -1088,7 +1682,7 @@
 			"attribute_index": -1,
 			"display_name": "test_temprory_children_is_dictionary",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_temprory_children_is_dictionary",
-			"guid": "0bacecf2-e2c2472-fa61c21-073a219084",
+			"guid": "e5aa9963-c2a945f-aac7ef8-2b173c321c",
 			"line_number": 131,
 			"metadata": {
 
@@ -1106,7 +1700,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_last_file_path_returns_string",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_get_last_file_path_returns_string",
-			"guid": "fbcd8bb9-6acc4a8-88fa451-cbe9b103f0",
+			"guid": "8020c9db-5df9447-fb7d3c5-05e97540ab",
 			"line_number": 134,
 			"metadata": {
 
@@ -1124,7 +1718,7 @@
 			"attribute_index": -1,
 			"display_name": "test_window_manager_constants",
 			"fully_qualified_name": "tests.core.autoload.global_test.test_window_manager_constants",
-			"guid": "0dea636b-e3764d3-ead331a-88dee0599e",
+			"guid": "f49b9854-f8f940a-ea404a6-6e37085716",
 			"line_number": 138,
 			"metadata": {
 
@@ -1142,8 +1736,8 @@
 			"attribute_index": -1,
 			"display_name": "test_settings_file_constant",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_settings_file_constant",
-			"guid": "87c5067a-9357417-b82ce4d-e1f83fb958",
-			"line_number": 27,
+			"guid": "36e032e1-590c4ef-c87b556-8fa43cf130",
+			"line_number": 41,
 			"metadata": {
 
 			},
@@ -1160,8 +1754,8 @@
 			"attribute_index": -1,
 			"display_name": "test_presets_file_constant",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_presets_file_constant",
-			"guid": "1a87fa7c-55ee405-199f4cc-aea2a0863e",
-			"line_number": 30,
+			"guid": "e747fce7-143247e-eb662c9-747d6a1742",
+			"line_number": 44,
 			"metadata": {
 
 			},
@@ -1178,8 +1772,8 @@
 			"attribute_index": -1,
 			"display_name": "test_data_file_constant",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_data_file_constant",
-			"guid": "4f9c735a-06904d5-391fc98-bbaa1b017f",
-			"line_number": 33,
+			"guid": "2a18df3f-e85d4c5-8b3608b-fabbf91770",
+			"line_number": 47,
 			"metadata": {
 
 			},
@@ -1196,8 +1790,8 @@
 			"attribute_index": -1,
 			"display_name": "test_settings_config_exists",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_settings_config_exists",
-			"guid": "d56d40aa-9a4f4c6-09655ce-66a6913bd9",
-			"line_number": 36,
+			"guid": "87117cda-f4a943c-9bc9fa8-da824b5083",
+			"line_number": 50,
 			"metadata": {
 
 			},
@@ -1214,8 +1808,8 @@
 			"attribute_index": -1,
 			"display_name": "test_presets_config_exists",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_presets_config_exists",
-			"guid": "45ea18cf-5da9443-4a68344-b44eac69a7",
-			"line_number": 40,
+			"guid": "e49754b7-f24543e-08868b5-ddfaf4496e",
+			"line_number": 54,
 			"metadata": {
 
 			},
@@ -1232,8 +1826,8 @@
 			"attribute_index": -1,
 			"display_name": "test_data_config_exists",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_data_config_exists",
-			"guid": "2066a138-4e86478-2951158-d9e255d044",
-			"line_number": 44,
+			"guid": "ec100186-63fd4a8-9b952e5-c2142a796f",
+			"line_number": 58,
 			"metadata": {
 
 			},
@@ -1250,8 +1844,8 @@
 			"attribute_index": -1,
 			"display_name": "test_define_preset_sets_value",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_define_preset_sets_value",
-			"guid": "22facd81-f2d041e-aa403d2-a651b9a8ef",
-			"line_number": 48,
+			"guid": "8e38e1e5-2ba5415-5bbe44c-67816c80b5",
+			"line_number": 62,
 			"metadata": {
 
 			},
@@ -1268,8 +1862,8 @@
 			"attribute_index": -1,
 			"display_name": "test_define_preset_overwrites_existing",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_define_preset_overwrites_existing",
-			"guid": "22b5d4f7-bac948b-c9679bf-f357bf880f",
-			"line_number": 53,
+			"guid": "f1b31545-f261423-59f934c-44fed0b5b1",
+			"line_number": 67,
 			"metadata": {
 
 			},
@@ -1286,8 +1880,8 @@
 			"attribute_index": -1,
 			"display_name": "test_get_default_returns_preset_value",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_get_default_returns_preset_value",
-			"guid": "b92a897f-cdba412-491ba06-f1dddadf8e",
-			"line_number": 59,
+			"guid": "3b8bdcf1-929f44f-2a76aee-336863dc87",
+			"line_number": 73,
 			"metadata": {
 
 			},
@@ -1304,8 +1898,8 @@
 			"attribute_index": -1,
 			"display_name": "test_get_default_returns_null_for_undefined",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_get_default_returns_null_for_undefined",
-			"guid": "d34c526a-204a4e3-cafd984-428328355d",
-			"line_number": 64,
+			"guid": "4a017555-57864c2-5b29e13-a4dc7546dc",
+			"line_number": 78,
 			"metadata": {
 
 			},
@@ -1322,8 +1916,8 @@
 			"attribute_index": -1,
 			"display_name": "test_set_setting_stores_value",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_set_setting_stores_value",
-			"guid": "b5e77fd4-801a4d5-7bdbcbc-b798e75fed",
-			"line_number": 68,
+			"guid": "e6df7afc-fc30449-ca164cb-e76e8a1ed2",
+			"line_number": 82,
 			"metadata": {
 
 			},
@@ -1340,8 +1934,8 @@
 			"attribute_index": -1,
 			"display_name": "test_get_setting_retrieves_stored_value",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_get_setting_retrieves_stored_value",
-			"guid": "040fef74-65ac4a0-d8e6506-f814d771a3",
-			"line_number": 73,
+			"guid": "1b40bab5-b8e94f4-b9386c2-7e656bd76d",
+			"line_number": 87,
 			"metadata": {
 
 			},
@@ -1358,8 +1952,8 @@
 			"attribute_index": -1,
 			"display_name": "test_get_setting_uses_default_when_not_set",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_get_setting_uses_default_when_not_set",
-			"guid": "7e74cc97-7204422-b97e387-be5bd2f2a3",
-			"line_number": 78,
+			"guid": "e215ec73-888e4f1-8af2baa-791915f640",
+			"line_number": 92,
 			"metadata": {
 
 			},
@@ -1376,8 +1970,8 @@
 			"attribute_index": -1,
 			"display_name": "test_get_setting_bool_returns_boolean",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_get_setting_bool_returns_boolean",
-			"guid": "4b0316a2-ef6d47c-1979c4c-d3223751cd",
-			"line_number": 83,
+			"guid": "5d5fea51-687840b-f889eaf-95da2b1cbd",
+			"line_number": 97,
 			"metadata": {
 
 			},
@@ -1394,8 +1988,8 @@
 			"attribute_index": -1,
 			"display_name": "test_get_setting_bool_converts_to_boolean",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_get_setting_bool_converts_to_boolean",
-			"guid": "ce38e6d7-d36a4e4-7825049-b6938f56a7",
-			"line_number": 88,
+			"guid": "12964367-46624bf-fa94f97-093efbc972",
+			"line_number": 102,
 			"metadata": {
 
 			},
@@ -1412,8 +2006,8 @@
 			"attribute_index": -1,
 			"display_name": "test_restore_default_resets_to_preset",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_restore_default_resets_to_preset",
-			"guid": "65c667e7-81e8410-bb978e8-de9e839575",
-			"line_number": 93,
+			"guid": "30286429-62ff4a0-3a8a573-26c25fd467",
+			"line_number": 107,
 			"metadata": {
 
 			},
@@ -1430,8 +2024,8 @@
 			"attribute_index": -1,
 			"display_name": "test_read_data_retrieves_value",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_read_data_retrieves_value",
-			"guid": "9700b09b-7bea4f3-b9fe7ba-cc6cb8cca0",
-			"line_number": 100,
+			"guid": "f445ef87-72b1415-5906bea-a2919b2c86",
+			"line_number": 114,
 			"metadata": {
 
 			},
@@ -1448,8 +2042,8 @@
 			"attribute_index": -1,
 			"display_name": "test_read_data_uses_default",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_read_data_uses_default",
-			"guid": "f949fbcf-fe894ac-895856e-6e457a22d5",
-			"line_number": 105,
+			"guid": "044378c3-6ca44fe-8b76bf5-8bd4873514",
+			"line_number": 119,
 			"metadata": {
 
 			},
@@ -1466,8 +2060,8 @@
 			"attribute_index": -1,
 			"display_name": "test_write_data_stores_value",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_write_data_stores_value",
-			"guid": "2a922e18-c2d24f8-8ad7eeb-5f896c0564",
-			"line_number": 109,
+			"guid": "ee4935cd-b800488-caeaa83-2babfb1edc",
+			"line_number": 123,
 			"metadata": {
 
 			},
@@ -1484,8 +2078,8 @@
 			"attribute_index": -1,
 			"display_name": "test_globalize_path_converts_user_path",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_globalize_path_converts_user_path",
-			"guid": "fb3d8276-de9a4e0-c90d667-93e197e318",
-			"line_number": 114,
+			"guid": "2996b6fc-8aaa4d0-eb41b03-5e8301da82",
+			"line_number": 128,
 			"metadata": {
 
 			},
@@ -1502,8 +2096,8 @@
 			"attribute_index": -1,
 			"display_name": "test_globalize_path_handles_res_path",
 			"fully_qualified_name": "tests.core.autoload.settings_test.test_globalize_path_handles_res_path",
-			"guid": "bbbdf3f9-b7e3410-0be8a09-f79cfd2fbe",
-			"line_number": 119,
+			"guid": "fbacdd94-42874f2-6a216e6-057a2eb554",
+			"line_number": 133,
 			"metadata": {
 
 			},
@@ -1518,9 +2112,189 @@
 			"@subpath": "",
 			"assembly_location": "",
 			"attribute_index": -1,
+			"display_name": "test_set_setting_early_return_when_value_unchanged",
+			"fully_qualified_name": "tests.core.autoload.settings_test.test_set_setting_early_return_when_value_unchanged",
+			"guid": "38420a74-bae0460-ab5ccdd-521a86921d",
+			"line_number": 139,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/autoload/settings_test.gd",
+			"suite_name": "settings_test",
+			"suite_resource_path": "res://tests/core/autoload/settings_test.gd",
+			"test_name": "test_set_setting_early_return_when_value_unchanged"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_set_setting_emits_signal_on_value_change",
+			"fully_qualified_name": "tests.core.autoload.settings_test.test_set_setting_emits_signal_on_value_change",
+			"guid": "56ad35be-7eaf498-ca679f3-80f8c806dc",
+			"line_number": 155,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/autoload/settings_test.gd",
+			"suite_name": "settings_test",
+			"suite_resource_path": "res://tests/core/autoload/settings_test.gd",
+			"test_name": "test_set_setting_emits_signal_on_value_change"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_set_setting_force_silent_suppresses_signal",
+			"fully_qualified_name": "tests.core.autoload.settings_test.test_set_setting_force_silent_suppresses_signal",
+			"guid": "fdfe25b2-75ea4d2-291fe2e-013c0ea393",
+			"line_number": 170,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/autoload/settings_test.gd",
+			"suite_name": "settings_test",
+			"suite_resource_path": "res://tests/core/autoload/settings_test.gd",
+			"test_name": "test_set_setting_force_silent_suppresses_signal"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_set_setting_force_silent_false_emits_signal",
+			"fully_qualified_name": "tests.core.autoload.settings_test.test_set_setting_force_silent_false_emits_signal",
+			"guid": "62480ef5-065a419-b9c621c-9d67eab174",
+			"line_number": 188,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/autoload/settings_test.gd",
+			"suite_name": "settings_test",
+			"suite_resource_path": "res://tests/core/autoload/settings_test.gd",
+			"test_name": "test_set_setting_force_silent_false_emits_signal"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_set_setting_early_return_with_same_numeric_value",
+			"fully_qualified_name": "tests.core.autoload.settings_test.test_set_setting_early_return_with_same_numeric_value",
+			"guid": "fa75acac-04f54d2-ebf1021-9eb59b1444",
+			"line_number": 203,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/autoload/settings_test.gd",
+			"suite_name": "settings_test",
+			"suite_resource_path": "res://tests/core/autoload/settings_test.gd",
+			"test_name": "test_set_setting_early_return_with_same_numeric_value"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_set_setting_early_return_with_same_boolean_value",
+			"fully_qualified_name": "tests.core.autoload.settings_test.test_set_setting_early_return_with_same_boolean_value",
+			"guid": "a7023614-66b14a7-09492ff-dc15bcfdbb",
+			"line_number": 215,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/autoload/settings_test.gd",
+			"suite_name": "settings_test",
+			"suite_resource_path": "res://tests/core/autoload/settings_test.gd",
+			"test_name": "test_set_setting_early_return_with_same_boolean_value"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_set_setting_early_return_with_same_float_value",
+			"fully_qualified_name": "tests.core.autoload.settings_test.test_set_setting_early_return_with_same_float_value",
+			"guid": "9c925af2-a034409-8aa4bd3-0b04f52203",
+			"line_number": 227,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/autoload/settings_test.gd",
+			"suite_name": "settings_test",
+			"suite_resource_path": "res://tests/core/autoload/settings_test.gd",
+			"test_name": "test_set_setting_early_return_with_same_float_value"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_set_setting_does_not_emit_on_save_error",
+			"fully_qualified_name": "tests.core.autoload.settings_test.test_set_setting_does_not_emit_on_save_error",
+			"guid": "2ee49030-dd21424-f8c28a0-6949102cfe",
+			"line_number": 239,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/autoload/settings_test.gd",
+			"suite_name": "settings_test",
+			"suite_resource_path": "res://tests/core/autoload/settings_test.gd",
+			"test_name": "test_set_setting_does_not_emit_on_save_error"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_restore_default_emits_settings_changed",
+			"fully_qualified_name": "tests.core.autoload.settings_test.test_restore_default_emits_settings_changed",
+			"guid": "f715414e-eef6435-2b3c305-771bc9a771",
+			"line_number": 244,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/autoload/settings_test.gd",
+			"suite_name": "settings_test",
+			"suite_resource_path": "res://tests/core/autoload/settings_test.gd",
+			"test_name": "test_restore_default_emits_settings_changed"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_restore_default_no_signal_if_already_default",
+			"fully_qualified_name": "tests.core.autoload.settings_test.test_restore_default_no_signal_if_already_default",
+			"guid": "a2bff4e8-d2584b4-e8cce8c-f807e7b9ac",
+			"line_number": 257,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/autoload/settings_test.gd",
+			"suite_name": "settings_test",
+			"suite_resource_path": "res://tests/core/autoload/settings_test.gd",
+			"test_name": "test_restore_default_no_signal_if_already_default"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
 			"display_name": "test_get_text_from_string_source",
 			"fully_qualified_name": "tests.core.autoload.translation_manager_test.test_get_text_from_string_source",
-			"guid": "4ef955f2-013e4bf-6a751d5-53b32c50f0",
+			"guid": "932d8746-ba324b3-da90b8c-8d4c1dc086",
 			"line_number": 16,
 			"metadata": {
 
@@ -1538,7 +2312,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_text_from_string_source_fallback",
 			"fully_qualified_name": "tests.core.autoload.translation_manager_test.test_get_text_from_string_source_fallback",
-			"guid": "e4741b7a-50e348c-1b63088-e026a8b916",
+			"guid": "95c663c2-bf0d4dd-0a799f5-9401d2311d",
 			"line_number": 19,
 			"metadata": {
 
@@ -1556,7 +2330,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_text_from_string_source_invalid_key",
 			"fully_qualified_name": "tests.core.autoload.translation_manager_test.test_get_text_from_string_source_invalid_key",
-			"guid": "f02c8ea1-fd4c4da-68c0ac2-87f345f96c",
+			"guid": "8aa437cc-d9bc435-5b014e5-b42deba041",
 			"line_number": 24,
 			"metadata": {
 
@@ -1574,7 +2348,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_text_from_string_source_invalid_lang",
 			"fully_qualified_name": "tests.core.autoload.translation_manager_test.test_get_text_from_string_source_invalid_lang",
-			"guid": "c8a7418e-c23b414-ea44b44-6c03b70ce1",
+			"guid": "31540495-a7804cf-094f58b-890911e24d",
 			"line_number": 27,
 			"metadata": {
 
@@ -1592,7 +2366,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_text_invalid_file",
 			"fully_qualified_name": "tests.core.autoload.translation_manager_test.test_get_text_invalid_file",
-			"guid": "fa85aa6b-cf844f4-998c7a6-7fab1c2bf3",
+			"guid": "19fead22-9d474ef-199a2f9-7921f1917d",
 			"line_number": 30,
 			"metadata": {
 
@@ -1610,7 +2384,7 @@
 			"attribute_index": -1,
 			"display_name": "test_set_language_restore_default",
 			"fully_qualified_name": "tests.core.autoload.translation_manager_test.test_set_language_restore_default",
-			"guid": "6a3fb684-f9fb48a-5a93c93-b356e08a98",
+			"guid": "277cc58a-9a5b4e4-78d526a-49395bd684",
 			"line_number": 33,
 			"metadata": {
 
@@ -1628,7 +2402,7 @@
 			"attribute_index": -1,
 			"display_name": "test_set_language_change",
 			"fully_qualified_name": "tests.core.autoload.translation_manager_test.test_set_language_change",
-			"guid": "5fbd07ff-87ac4d4-29f54ba-fde8d05a94",
+			"guid": "26a7360e-dcef4c0-982be37-0c5fe719fd",
 			"line_number": 40,
 			"metadata": {
 
@@ -1646,7 +2420,7 @@
 			"attribute_index": -1,
 			"display_name": "test_syntax_colors_enum_count",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_syntax_colors_enum_count",
-			"guid": "e91c6fc7-e1d6463-aa30eb0-43c94c318c",
+			"guid": "9033e11a-4cb44de-78738c4-30e7761b0c",
 			"line_number": 13,
 			"metadata": {
 
@@ -1664,7 +2438,7 @@
 			"attribute_index": -1,
 			"display_name": "test_syntax_colors_map_completeness",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_syntax_colors_map_completeness",
-			"guid": "3f54f288-49d3405-dba6f8b-183f9f103c",
+			"guid": "6dfd3fc3-132841b-6bf7f4a-4ae79acf50",
 			"line_number": 17,
 			"metadata": {
 
@@ -1682,7 +2456,7 @@
 			"attribute_index": -1,
 			"display_name": "test_syntax_colors_map_builtin",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_syntax_colors_map_builtin",
-			"guid": "e30dd333-053c48a-daeedef-7040d78f68",
+			"guid": "b56bfd36-cf2d43a-4b43a55-82d45c9157",
 			"line_number": 21,
 			"metadata": {
 
@@ -1700,7 +2474,7 @@
 			"attribute_index": -1,
 			"display_name": "test_syntax_colors_map_comment",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_syntax_colors_map_comment",
-			"guid": "33101cc6-f5374e6-f943ea7-1c62a372fd",
+			"guid": "ff5be177-efe349b-9825472-13ea3920f5",
 			"line_number": 24,
 			"metadata": {
 
@@ -1718,7 +2492,7 @@
 			"attribute_index": -1,
 			"display_name": "test_syntax_colors_map_string",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_syntax_colors_map_string",
-			"guid": "4d66913b-2fe44de-d94c164-34fecaecf4",
+			"guid": "c7dce399-ad33416-cae441a-e121d00f04",
 			"line_number": 27,
 			"metadata": {
 
@@ -1736,7 +2510,7 @@
 			"attribute_index": -1,
 			"display_name": "test_syntax_colors_map_number",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_syntax_colors_map_number",
-			"guid": "ec28c900-b1eb445-8a7abdb-5fd7695b83",
+			"guid": "6c154c58-2c67464-2927de7-bb0e2d7486",
 			"line_number": 30,
 			"metadata": {
 
@@ -1754,7 +2528,7 @@
 			"attribute_index": -1,
 			"display_name": "test_syntax_colors_map_function",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_syntax_colors_map_function",
-			"guid": "3a06646c-9d91428-389eed4-a9e6ecde0a",
+			"guid": "369d9ca7-5ec54f3-fad8087-73138f98c7",
 			"line_number": 33,
 			"metadata": {
 
@@ -1772,7 +2546,7 @@
 			"attribute_index": -1,
 			"display_name": "test_syntax_colors_map_keyword_1",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_syntax_colors_map_keyword_1",
-			"guid": "197b815b-ef5b427-68e9726-8baebefa27",
+			"guid": "57ebf789-c4c44ac-f9966f7-5429277ef4",
 			"line_number": 36,
 			"metadata": {
 
@@ -1790,7 +2564,7 @@
 			"attribute_index": -1,
 			"display_name": "test_syntax_colors_map_type_1",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_syntax_colors_map_type_1",
-			"guid": "1d7a02d0-8a52446-8ad8490-6fed995284",
+			"guid": "8070a879-a54640f-aad2ef4-c37fa82fb5",
 			"line_number": 39,
 			"metadata": {
 
@@ -1808,7 +2582,7 @@
 			"attribute_index": -1,
 			"display_name": "test_wait_zero_waits_one_frame",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_wait_zero_waits_one_frame",
-			"guid": "e2a3c8d4-c5b54ec-0a395a7-d2772ac5b7",
+			"guid": "27195282-845944f-9bd847f-9d91304d1a",
 			"line_number": 42,
 			"metadata": {
 
@@ -1826,7 +2600,7 @@
 			"attribute_index": -1,
 			"display_name": "test_wait_with_time_creates_timer",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_wait_with_time_creates_timer",
-			"guid": "dfb36d71-5f9c4ae-98dbe0d-fcd0b4d8cc",
+			"guid": "c7c539a7-c9d9400-da5da72-4789e552a8",
 			"line_number": 49,
 			"metadata": {
 
@@ -1844,7 +2618,7 @@
 			"attribute_index": -1,
 			"display_name": "test_load_resource_returns_null_for_empty_path",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_load_resource_returns_null_for_empty_path",
-			"guid": "4d270089-ea4e466-f9e6faf-6c7577732a",
+			"guid": "067e6954-1a6c440-ab1013d-d0b1913655",
 			"line_number": 56,
 			"metadata": {
 
@@ -1862,7 +2636,7 @@
 			"attribute_index": -1,
 			"display_name": "test_load_resource_loads_valid_resource",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_load_resource_loads_valid_resource",
-			"guid": "91f53443-224d40d-cb1942e-8d5a4fefcd",
+			"guid": "734c9b76-f0c84be-69b3f6e-83e1f2d298",
 			"line_number": 60,
 			"metadata": {
 
@@ -1880,7 +2654,7 @@
 			"attribute_index": -1,
 			"display_name": "test_load_resource_handles_invalid_path",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_load_resource_handles_invalid_path",
-			"guid": "0a1442c8-269b45e-4ad34cc-c3b7404a33",
+			"guid": "84b66483-d0e0408-4b66bcc-fbb6bbb0a4",
 			"line_number": 65,
 			"metadata": {
 
@@ -1898,7 +2672,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_syntax_color_returns_color",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_get_syntax_color_returns_color",
-			"guid": "52ed0bfb-a1b64c9-ab08a60-cf8198cf83",
+			"guid": "3497a19a-f16f4e1-d9d61ce-22782aa02b",
 			"line_number": 69,
 			"metadata": {
 
@@ -1916,7 +2690,7 @@
 			"attribute_index": -1,
 			"display_name": "test_format_stack_removes_res_prefix",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_format_stack_removes_res_prefix",
-			"guid": "8a53db36-2e1f4a1-6b22708-c9c69aead9",
+			"guid": "80caccf3-156e442-8a0b3f7-b63883018a",
 			"line_number": 73,
 			"metadata": {
 
@@ -1934,7 +2708,7 @@
 			"attribute_index": -1,
 			"display_name": "test_format_stack_includes_line_number",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_format_stack_includes_line_number",
-			"guid": "aaa31cab-5f2a4fb-487a415-30ade8399d",
+			"guid": "6cb052cc-fddf450-cba4944-38c453f3c4",
 			"line_number": 78,
 			"metadata": {
 
@@ -1952,7 +2726,7 @@
 			"attribute_index": -1,
 			"display_name": "test_format_stack_includes_function_name",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_format_stack_includes_function_name",
-			"guid": "e12cee73-cab24d3-298bc7c-84522cd08f",
+			"guid": "eab2dd44-00a74ba-f9ad967-dabe3eeee9",
 			"line_number": 83,
 			"metadata": {
 
@@ -1970,7 +2744,7 @@
 			"attribute_index": -1,
 			"display_name": "test_threaded_loader_initializes",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_threaded_loader_initializes",
-			"guid": "4ec89fb1-ced741f-db0f48c-1725305985",
+			"guid": "611ed5e6-61aa433-da69fe7-a0fb42d688",
 			"line_number": 88,
 			"metadata": {
 
@@ -1988,7 +2762,7 @@
 			"attribute_index": -1,
 			"display_name": "test_threaded_loader_handles_empty_paths",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_threaded_loader_handles_empty_paths",
-			"guid": "0e08f07d-090147a-4bedf12-eb1abb7c1d",
+			"guid": "78c1de47-c645426-fac4ffa-3156ea75d4",
 			"line_number": 93,
 			"metadata": {
 
@@ -2006,7 +2780,7 @@
 			"attribute_index": -1,
 			"display_name": "test_load_resources_threaded_creates_loader",
 			"fully_qualified_name": "tests.core.autoload.utils_test.test_load_resources_threaded_creates_loader",
-			"guid": "8fcc0c33-0085499-1b8a2b9-04effa379b",
+			"guid": "60efd78b-38654f0-1a91249-ee546fc4b4",
 			"line_number": 101,
 			"metadata": {
 
@@ -2024,7 +2798,7 @@
 			"attribute_index": -1,
 			"display_name": "test_save_bookmarks_method_exists",
 			"fully_qualified_name": "tests.core.editor_api_test.test_save_bookmarks_method_exists",
-			"guid": "0c79569e-e8a24c0-4a79e44-a5fafeb363",
+			"guid": "a8726e1d-46a840c-5bc3016-db7a3b675e",
 			"line_number": 14,
 			"metadata": {
 
@@ -2042,7 +2816,7 @@
 			"attribute_index": -1,
 			"display_name": "test_load_bookmarks_method_exists",
 			"fully_qualified_name": "tests.core.editor_api_test.test_load_bookmarks_method_exists",
-			"guid": "dc83e3c0-cb9a4aa-f99b0de-cfc04816b4",
+			"guid": "c3836d3b-1ccb4c5-5a6ade0-1ae2e84d93",
 			"line_number": 19,
 			"metadata": {
 
@@ -2060,7 +2834,7 @@
 			"attribute_index": -1,
 			"display_name": "test_editor_api_extends_control",
 			"fully_qualified_name": "tests.core.editor_api_test.test_editor_api_extends_control",
-			"guid": "48f096b4-793c44f-d80ca58-1c08cb93b6",
+			"guid": "8c40cdc8-7a4b414-38de09a-96b2a89562",
 			"line_number": 24,
 			"metadata": {
 
@@ -2078,7 +2852,7 @@
 			"attribute_index": -1,
 			"display_name": "test_ready_creates_type_timer",
 			"fully_qualified_name": "tests.core.editor_test.test_ready_creates_type_timer",
-			"guid": "b8d32c13-693c4e0-5860640-c1942706da",
+			"guid": "cdb801d7-6bdf4c8-1af8da9-cb7d5b6d0f",
 			"line_number": 18,
 			"metadata": {
 
@@ -2096,7 +2870,7 @@
 			"attribute_index": -1,
 			"display_name": "test_type_timer_configured_correctly",
 			"fully_qualified_name": "tests.core.editor_test.test_type_timer_configured_correctly",
-			"guid": "4e525f7b-bfcb49b-c890865-e353411244",
+			"guid": "3cb3b379-40ec47b-2a0c816-5d9c69c2ae",
 			"line_number": 22,
 			"metadata": {
 
@@ -2114,7 +2888,7 @@
 			"attribute_index": -1,
 			"display_name": "test_ready_sets_gutter_clickable",
 			"fully_qualified_name": "tests.core.editor_test.test_ready_sets_gutter_clickable",
-			"guid": "96b5a274-2c0340c-096b70d-6c72368399",
+			"guid": "053cb590-d78f4cc-7a2ba98-95f892a925",
 			"line_number": 26,
 			"metadata": {
 
@@ -2132,7 +2906,7 @@
 			"attribute_index": -1,
 			"display_name": "test_type_timer_is_child_of_editor",
 			"fully_qualified_name": "tests.core.editor_test.test_type_timer_is_child_of_editor",
-			"guid": "74bfa1ef-940b443-7806173-bc6eccc735",
+			"guid": "c6d70732-92e14d8-7a81eb0-b579dcb007",
 			"line_number": 30,
 			"metadata": {
 
@@ -2150,7 +2924,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_char_index_single_line",
 			"fully_qualified_name": "tests.core.editor_test.test_get_char_index_single_line",
-			"guid": "32a93203-d9f149d-9927863-bcf7047996",
+			"guid": "c4bcfb51-49dd4f9-3b0a81e-e02dd2808a",
 			"line_number": 33,
 			"metadata": {
 
@@ -2168,7 +2942,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_char_index_at_start",
 			"fully_qualified_name": "tests.core.editor_test.test_get_char_index_at_start",
-			"guid": "fb897890-2068452-ca2b74c-644a491ba9",
+			"guid": "42a7887c-fe68422-0829f1e-8d447089af",
 			"line_number": 38,
 			"metadata": {
 
@@ -2186,7 +2960,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_char_index_at_end",
 			"fully_qualified_name": "tests.core.editor_test.test_get_char_index_at_end",
-			"guid": "fb088eb5-8957489-38797c0-842dedaa1f",
+			"guid": "668fa62c-6165458-c814678-273a8404b7",
 			"line_number": 43,
 			"metadata": {
 
@@ -2204,7 +2978,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_char_index_multiline",
 			"fully_qualified_name": "tests.core.editor_test.test_get_char_index_multiline",
-			"guid": "0f69c0f7-9f69418-9a08217-0b1660893f",
+			"guid": "7c2e8f14-182d46c-9aa6eec-802ab5b3af",
 			"line_number": 48,
 			"metadata": {
 
@@ -2222,7 +2996,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_char_index_multiline_with_offset",
 			"fully_qualified_name": "tests.core.editor_test.test_get_char_index_multiline_with_offset",
-			"guid": "8821cfbb-36c3405-4bb604f-1300b0cf07",
+			"guid": "aff2f01e-1f6b4d3-68f1c9d-349c8b1a94",
 			"line_number": 54,
 			"metadata": {
 
@@ -2240,7 +3014,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_char_index_third_line",
 			"fully_qualified_name": "tests.core.editor_test.test_get_char_index_third_line",
-			"guid": "1ca3ff0f-ce7042d-0bfa6d0-4c33211408",
+			"guid": "24d561f2-0028422-39e9189-42673372a2",
 			"line_number": 60,
 			"metadata": {
 
@@ -2258,7 +3032,7 @@
 			"attribute_index": -1,
 			"display_name": "test_get_char_index_empty_text",
 			"fully_qualified_name": "tests.core.editor_test.test_get_char_index_empty_text",
-			"guid": "1e8ed093-28584f7-a9e438e-5a6397fb33",
+			"guid": "24f3f042-b46e4a3-7a29411-e70c78210a",
 			"line_number": 66,
 			"metadata": {
 
@@ -2276,7 +3050,7 @@
 			"attribute_index": -1,
 			"display_name": "test_is_selection_in_line_caret_only",
 			"fully_qualified_name": "tests.core.editor_test.test_is_selection_in_line_caret_only",
-			"guid": "5e034647-6c3e431-090c4e0-2632cdbd21",
+			"guid": "ef7a9c43-c5414f0-09a275d-d4b51e5ec8",
 			"line_number": 71,
 			"metadata": {
 
@@ -2294,7 +3068,7 @@
 			"attribute_index": -1,
 			"display_name": "test_is_selection_in_line_with_selection",
 			"fully_qualified_name": "tests.core.editor_test.test_is_selection_in_line_with_selection",
-			"guid": "bf965315-87c840f-581bd96-121b424765",
+			"guid": "d6d86bf8-d45a4a5-d9f6f54-6f6c5ba5a8",
 			"line_number": 81,
 			"metadata": {
 
@@ -2312,7 +3086,7 @@
 			"attribute_index": -1,
 			"display_name": "test_is_selection_in_line_reversed_selection",
 			"fully_qualified_name": "tests.core.editor_test.test_is_selection_in_line_reversed_selection",
-			"guid": "39745a97-42eb4f2-98f9161-b781fbe044",
+			"guid": "22fe07f7-cee4461-2980fdf-60932d4566",
 			"line_number": 92,
 			"metadata": {
 
@@ -2330,7 +3104,7 @@
 			"attribute_index": -1,
 			"display_name": "test_is_selection_in_line_single_line_selection",
 			"fully_qualified_name": "tests.core.editor_test.test_is_selection_in_line_single_line_selection",
-			"guid": "c61c8500-2d5c43b-ab524de-ff0690fdd3",
+			"guid": "8218bc09-44c0415-e900fdf-346725d869",
 			"line_number": 101,
 			"metadata": {
 
@@ -2348,7 +3122,7 @@
 			"attribute_index": -1,
 			"display_name": "test_on_text_changed_starts_timer",
 			"fully_qualified_name": "tests.core.editor_test.test_on_text_changed_starts_timer",
-			"guid": "f518e2e0-5968429-3a495bf-de95fe92aa",
+			"guid": "d8081300-25894d6-7893a53-b46a59c266",
 			"line_number": 108,
 			"metadata": {
 
@@ -2366,7 +3140,7 @@
 			"attribute_index": -1,
 			"display_name": "test_on_text_changed_restarts_timer",
 			"fully_qualified_name": "tests.core.editor_test.test_on_text_changed_restarts_timer",
-			"guid": "26aa4694-e5534b0-baebbe2-d6fdc8accb",
+			"guid": "7a293c9b-e6e94ed-899a5b7-66282ce18b",
 			"line_number": 117,
 			"metadata": {
 
@@ -2384,7 +3158,7 @@
 			"attribute_index": -1,
 			"display_name": "test_on_gutter_clicked_not_editable_does_nothing",
 			"fully_qualified_name": "tests.core.editor_test.test_on_gutter_clicked_not_editable_does_nothing",
-			"guid": "dc4a1762-0acb452-983975c-ead875262e",
+			"guid": "48387ed2-d01c4aa-4a8c64c-b344d9b158",
 			"line_number": 126,
 			"metadata": {
 
@@ -2402,7 +3176,7 @@
 			"attribute_index": -1,
 			"display_name": "test_on_gutter_clicked_wrong_gutter_does_nothing",
 			"fully_qualified_name": "tests.core.editor_test.test_on_gutter_clicked_wrong_gutter_does_nothing",
-			"guid": "032b624b-3c2e495-4a67718-7ea448decb",
+			"guid": "b7e51ab7-62824aa-fb05e23-5fe2cb6922",
 			"line_number": 134,
 			"metadata": {
 
@@ -2420,7 +3194,7 @@
 			"attribute_index": -1,
 			"display_name": "test_on_gutter_clicked_gutter_2_does_nothing",
 			"fully_qualified_name": "tests.core.editor_test.test_on_gutter_clicked_gutter_2_does_nothing",
-			"guid": "990a00f6-49024e5-f977a22-4b0de8b5ef",
+			"guid": "31030b64-7fab482-38b44db-00aa14da64",
 			"line_number": 143,
 			"metadata": {
 
@@ -2438,7 +3212,7 @@
 			"attribute_index": -1,
 			"display_name": "test_on_gutter_clicked_sets_bookmark",
 			"fully_qualified_name": "tests.core.editor_test.test_on_gutter_clicked_sets_bookmark",
-			"guid": "15d35977-8c98408-8bd279e-a93aab6ce3",
+			"guid": "9c429562-bf674d7-3a4a60f-dd98784070",
 			"line_number": 151,
 			"metadata": {
 
@@ -2456,7 +3230,7 @@
 			"attribute_index": -1,
 			"display_name": "test_on_gutter_clicked_toggles_bookmark_on",
 			"fully_qualified_name": "tests.core.editor_test.test_on_gutter_clicked_toggles_bookmark_on",
-			"guid": "103c4bf4-bcc242e-b84cf52-494b983ac7",
+			"guid": "d037c2f2-0a0f44d-29f3c08-21c3078aba",
 			"line_number": 159,
 			"metadata": {
 
@@ -2474,7 +3248,7 @@
 			"attribute_index": -1,
 			"display_name": "test_on_gutter_clicked_toggles_bookmark_off",
 			"fully_qualified_name": "tests.core.editor_test.test_on_gutter_clicked_toggles_bookmark_off",
-			"guid": "73148c31-a2984f3-db549bc-1c945f5255",
+			"guid": "eb5b6446-38c9463-f935182-f8379e57ec",
 			"line_number": 168,
 			"metadata": {
 
@@ -2492,7 +3266,7 @@
 			"attribute_index": -1,
 			"display_name": "test_on_gutter_clicked_multiple_lines",
 			"fully_qualified_name": "tests.core.editor_test.test_on_gutter_clicked_multiple_lines",
-			"guid": "9b640d3e-d0ab4ea-79e91aa-ea9bce8d91",
+			"guid": "05fd9ac1-946d457-2866551-6a826c71c8",
 			"line_number": 178,
 			"metadata": {
 
@@ -2510,7 +3284,7 @@
 			"attribute_index": -1,
 			"display_name": "test_on_gutter_clicked_toggle_sequence",
 			"fully_qualified_name": "tests.core.editor_test.test_on_gutter_clicked_toggle_sequence",
-			"guid": "bf9625fa-a25d43c-297fa39-a3200fc018",
+			"guid": "464b1873-6b4e4c7-eab4e7c-6715d1b8c6",
 			"line_number": 192,
 			"metadata": {
 
@@ -2526,9 +3300,819 @@
 			"@subpath": "",
 			"assembly_location": "",
 			"attribute_index": -1,
+			"display_name": "test_ui_filter_presets_defined",
+			"fully_qualified_name": "tests.core.main_test.test_ui_filter_presets_defined",
+			"guid": "4f4b2a84-75dc4f8-6882091-e838b1a9cd",
+			"line_number": 25,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_ui_filter_presets_defined"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_hue_shift_default_value",
+			"fully_qualified_name": "tests.core.main_test.test_ui_filter_hue_shift_default_value",
+			"guid": "2a19f5e1-d6354b1-ba6cf88-4684619fad",
+			"line_number": 31,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_ui_filter_hue_shift_default_value"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_saturation_default_value",
+			"fully_qualified_name": "tests.core.main_test.test_ui_filter_saturation_default_value",
+			"guid": "a539e6e9-c8554a4-eaab9e9-6c828061a6",
+			"line_number": 35,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_ui_filter_saturation_default_value"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_brightness_default_value",
+			"fully_qualified_name": "tests.core.main_test.test_ui_filter_brightness_default_value",
+			"guid": "ea5ee1f5-1ece4c6-aa39a0a-210642b177",
+			"line_number": 39,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_ui_filter_brightness_default_value"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_hue_shift_range",
+			"fully_qualified_name": "tests.core.main_test.test_ui_filter_hue_shift_range",
+			"guid": "92447acc-dc74429-6949c76-687b2556fe",
+			"line_number": 43,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_ui_filter_hue_shift_range"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_saturation_range",
+			"fully_qualified_name": "tests.core.main_test.test_ui_filter_saturation_range",
+			"guid": "addbae29-56e64b6-49bd01f-d094f11566",
+			"line_number": 57,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_ui_filter_saturation_range"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_brightness_range",
+			"fully_qualified_name": "tests.core.main_test.test_ui_filter_brightness_range",
+			"guid": "0c488f27-47dd4cb-aa03e49-97c5dd05d6",
+			"line_number": 68,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_ui_filter_brightness_range"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_shader_parameters_updated",
+			"fully_qualified_name": "tests.core.main_test.test_ui_filter_shader_parameters_updated",
+			"guid": "b4460b5e-e9a0490-6af7f04-4ed43e5636",
+			"line_number": 79,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_ui_filter_shader_parameters_updated"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_theme_preset_exists",
+			"fully_qualified_name": "tests.core.main_test.test_theme_preset_exists",
+			"guid": "47fbdc6c-010f453-d8b8ada-096fc69236",
+			"line_number": 91,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_theme_preset_exists"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_theme_default_value",
+			"fully_qualified_name": "tests.core.main_test.test_theme_default_value",
+			"guid": "315880dd-09d94d9-7be5cc2-2f0f7df3c3",
+			"line_number": 94,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_theme_default_value"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_settings_independent",
+			"fully_qualified_name": "tests.core.main_test.test_ui_filter_settings_independent",
+			"guid": "7c29ce95-178b402-394638e-bfbc4ca2fe",
+			"line_number": 98,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_ui_filter_settings_independent"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_grayscale_effect",
+			"fully_qualified_name": "tests.core.main_test.test_ui_filter_grayscale_effect",
+			"guid": "5cb4ee31-222e42a-8b542b7-1517bccc4a",
+			"line_number": 108,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_ui_filter_grayscale_effect"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_maximum_saturation",
+			"fully_qualified_name": "tests.core.main_test.test_ui_filter_maximum_saturation",
+			"guid": "136d10d3-c11a434-696e0ec-c11459c891",
+			"line_number": 113,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_ui_filter_maximum_saturation"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_dark_mode",
+			"fully_qualified_name": "tests.core.main_test.test_ui_filter_dark_mode",
+			"guid": "a082d7ee-4a774a5-0b7e940-a5d5ac059f",
+			"line_number": 118,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_ui_filter_dark_mode"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_bright_mode",
+			"fully_qualified_name": "tests.core.main_test.test_ui_filter_bright_mode",
+			"guid": "cf38aef6-b32f4d2-eaf62a9-d962a1257b",
+			"line_number": 123,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_ui_filter_bright_mode"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_hue_rotation_positive",
+			"fully_qualified_name": "tests.core.main_test.test_ui_filter_hue_rotation_positive",
+			"guid": "33cc9101-08174fe-b809978-c37b74b73a",
+			"line_number": 128,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_ui_filter_hue_rotation_positive"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_hue_rotation_negative",
+			"fully_qualified_name": "tests.core.main_test.test_ui_filter_hue_rotation_negative",
+			"guid": "368a6f22-a067414-191ff92-d7bf9a4621",
+			"line_number": 133,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_ui_filter_hue_rotation_negative"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_reset_to_defaults",
+			"fully_qualified_name": "tests.core.main_test.test_ui_filter_reset_to_defaults",
+			"guid": "5aec4779-72644d2-c8057a1-a260fcc54d",
+			"line_number": 138,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_ui_filter_reset_to_defaults"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_extreme_values",
+			"fully_qualified_name": "tests.core.main_test.test_ui_filter_extreme_values",
+			"guid": "9fce7c5c-9cbc4da-6af6f8f-65aa675dc3",
+			"line_number": 154,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/main_test.gd",
+			"suite_name": "main_test",
+			"suite_resource_path": "res://tests/core/main_test.gd",
+			"test_name": "test_ui_filter_extreme_values"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_shader_file_exists",
+			"fully_qualified_name": "tests.core.shader_validation_test.test_shader_file_exists",
+			"guid": "90b0c3c2-04b6449-9b82a1b-8fb148d874",
+			"line_number": 10,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/shader_validation_test.gd",
+			"suite_name": "shader_validation_test",
+			"suite_resource_path": "res://tests/core/shader_validation_test.gd",
+			"test_name": "test_shader_file_exists"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_shader_loads_successfully",
+			"fully_qualified_name": "tests.core.shader_validation_test.test_shader_loads_successfully",
+			"guid": "90982c26-4a17403-cbbea2c-a68e13310c",
+			"line_number": 13,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/shader_validation_test.gd",
+			"suite_name": "shader_validation_test",
+			"suite_resource_path": "res://tests/core/shader_validation_test.gd",
+			"test_name": "test_shader_loads_successfully"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_shader_has_required_uniforms",
+			"fully_qualified_name": "tests.core.shader_validation_test.test_shader_has_required_uniforms",
+			"guid": "410db459-f4f64eb-488fb6c-d505a7ca7c",
+			"line_number": 18,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/shader_validation_test.gd",
+			"suite_name": "shader_validation_test",
+			"suite_resource_path": "res://tests/core/shader_validation_test.gd",
+			"test_name": "test_shader_has_required_uniforms"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_shader_has_hsv_conversion_functions",
+			"fully_qualified_name": "tests.core.shader_validation_test.test_shader_has_hsv_conversion_functions",
+			"guid": "5dc96639-86ef467-8a50394-bba17e32be",
+			"line_number": 28,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/shader_validation_test.gd",
+			"suite_name": "shader_validation_test",
+			"suite_resource_path": "res://tests/core/shader_validation_test.gd",
+			"test_name": "test_shader_has_hsv_conversion_functions"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_shader_has_fragment_function",
+			"fully_qualified_name": "tests.core.shader_validation_test.test_shader_has_fragment_function",
+			"guid": "fa97ae54-611d441-a8ad63b-936d3b4e6e",
+			"line_number": 37,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/shader_validation_test.gd",
+			"suite_name": "shader_validation_test",
+			"suite_resource_path": "res://tests/core/shader_validation_test.gd",
+			"test_name": "test_shader_has_fragment_function"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_shader_type_is_canvas_item",
+			"fully_qualified_name": "tests.core.shader_validation_test.test_shader_type_is_canvas_item",
+			"guid": "c03625e7-3744435-093fc56-4d5f991e5a",
+			"line_number": 43,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/shader_validation_test.gd",
+			"suite_name": "shader_validation_test",
+			"suite_resource_path": "res://tests/core/shader_validation_test.gd",
+			"test_name": "test_shader_type_is_canvas_item"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_shader_material_can_be_created",
+			"fully_qualified_name": "tests.core.shader_validation_test.test_shader_material_can_be_created",
+			"guid": "75f69243-b1be4dd-aa27326-be809dda0b",
+			"line_number": 49,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/shader_validation_test.gd",
+			"suite_name": "shader_validation_test",
+			"suite_resource_path": "res://tests/core/shader_validation_test.gd",
+			"test_name": "test_shader_material_can_be_created"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_shader_default_uniform_values",
+			"fully_qualified_name": "tests.core.shader_validation_test.test_shader_default_uniform_values",
+			"guid": "4fbaa1a7-88e7452-5802594-969e9d981f",
+			"line_number": 57,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/shader_validation_test.gd",
+			"suite_name": "shader_validation_test",
+			"suite_resource_path": "res://tests/core/shader_validation_test.gd",
+			"test_name": "test_shader_default_uniform_values"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_shader_hue_shift_parameter",
+			"fully_qualified_name": "tests.core.shader_validation_test.test_shader_hue_shift_parameter",
+			"guid": "dcd4bbaa-ad9f41c-5aaff12-0004612e6f",
+			"line_number": 71,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/shader_validation_test.gd",
+			"suite_name": "shader_validation_test",
+			"suite_resource_path": "res://tests/core/shader_validation_test.gd",
+			"test_name": "test_shader_hue_shift_parameter"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_shader_saturation_parameter",
+			"fully_qualified_name": "tests.core.shader_validation_test.test_shader_saturation_parameter",
+			"guid": "707b6a2e-00cd451-2b0f0cc-d632c08717",
+			"line_number": 86,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/shader_validation_test.gd",
+			"suite_name": "shader_validation_test",
+			"suite_resource_path": "res://tests/core/shader_validation_test.gd",
+			"test_name": "test_shader_saturation_parameter"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_shader_brightness_parameter",
+			"fully_qualified_name": "tests.core.shader_validation_test.test_shader_brightness_parameter",
+			"guid": "aedfe582-7f7f434-fa82730-287a6101e0",
+			"line_number": 97,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/shader_validation_test.gd",
+			"suite_name": "shader_validation_test",
+			"suite_resource_path": "res://tests/core/shader_validation_test.gd",
+			"test_name": "test_shader_brightness_parameter"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_shader_uid_file_exists",
+			"fully_qualified_name": "tests.core.shader_validation_test.test_shader_uid_file_exists",
+			"guid": "96228368-5096478-4b7934f-9076380c9e",
+			"line_number": 108,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/shader_validation_test.gd",
+			"suite_name": "shader_validation_test",
+			"suite_resource_path": "res://tests/core/shader_validation_test.gd",
+			"test_name": "test_shader_uid_file_exists"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_shader_uid_format",
+			"fully_qualified_name": "tests.core.shader_validation_test.test_shader_uid_format",
+			"guid": "81ea6a16-963f454-ab331ee-dc66f4e3d2",
+			"line_number": 111,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/shader_validation_test.gd",
+			"suite_name": "shader_validation_test",
+			"suite_resource_path": "res://tests/core/shader_validation_test.gd",
+			"test_name": "test_shader_uid_format"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_color_rect_with_shader_material",
+			"fully_qualified_name": "tests.core.shader_validation_test.test_color_rect_with_shader_material",
+			"guid": "8bf15359-c79041b-3922895-bcab900b25",
+			"line_number": 115,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/shader_validation_test.gd",
+			"suite_name": "shader_validation_test",
+			"suite_resource_path": "res://tests/core/shader_validation_test.gd",
+			"test_name": "test_color_rect_with_shader_material"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_shader_all_parameters_together",
+			"fully_qualified_name": "tests.core.shader_validation_test.test_shader_all_parameters_together",
+			"guid": "5ed862b4-e4b0459-6b64f7b-02dab295fc",
+			"line_number": 125,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/shader_validation_test.gd",
+			"suite_name": "shader_validation_test",
+			"suite_resource_path": "res://tests/core/shader_validation_test.gd",
+			"test_name": "test_shader_all_parameters_together"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_complete_ui_filter_workflow",
+			"fully_qualified_name": "tests.core.ui_filter_integration_test.test_complete_ui_filter_workflow",
+			"guid": "849ebe5c-71dc407-3ae5cd8-aff0304500",
+			"line_number": 28,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/ui_filter_integration_test.gd",
+			"suite_name": "ui_filter_integration_test",
+			"suite_resource_path": "res://tests/core/ui_filter_integration_test.gd",
+			"test_name": "test_complete_ui_filter_workflow"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_multiple_filter_changes_batch",
+			"fully_qualified_name": "tests.core.ui_filter_integration_test.test_multiple_filter_changes_batch",
+			"guid": "94ef1265-81e1410-1b1ace0-91780759e2",
+			"line_number": 41,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/ui_filter_integration_test.gd",
+			"suite_name": "ui_filter_integration_test",
+			"suite_resource_path": "res://tests/core/ui_filter_integration_test.gd",
+			"test_name": "test_multiple_filter_changes_batch"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_with_silent_mode",
+			"fully_qualified_name": "tests.core.ui_filter_integration_test.test_ui_filter_with_silent_mode",
+			"guid": "9f1fb528-06b44a8-5a04fad-b9525daaf2",
+			"line_number": 56,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/ui_filter_integration_test.gd",
+			"suite_name": "ui_filter_integration_test",
+			"suite_resource_path": "res://tests/core/ui_filter_integration_test.gd",
+			"test_name": "test_ui_filter_with_silent_mode"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_preset_consistency",
+			"fully_qualified_name": "tests.core.ui_filter_integration_test.test_ui_filter_preset_consistency",
+			"guid": "73927d0e-5511443-08c7246-5f80392b96",
+			"line_number": 77,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/ui_filter_integration_test.gd",
+			"suite_name": "ui_filter_integration_test",
+			"suite_resource_path": "res://tests/core/ui_filter_integration_test.gd",
+			"test_name": "test_ui_filter_preset_consistency"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_color_transformations",
+			"fully_qualified_name": "tests.core.ui_filter_integration_test.test_ui_filter_color_transformations",
+			"guid": "5223913f-03ce4c9-1b52a7d-dc1d94c2d5",
+			"line_number": 84,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/ui_filter_integration_test.gd",
+			"suite_name": "ui_filter_integration_test",
+			"suite_resource_path": "res://tests/core/ui_filter_integration_test.gd",
+			"test_name": "test_ui_filter_color_transformations"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_accessibility_modes",
+			"fully_qualified_name": "tests.core.ui_filter_integration_test.test_ui_filter_accessibility_modes",
+			"guid": "45393770-21d64d2-c8dda1d-bb8e30fa24",
+			"line_number": 101,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/ui_filter_integration_test.gd",
+			"suite_name": "ui_filter_integration_test",
+			"suite_resource_path": "res://tests/core/ui_filter_integration_test.gd",
+			"test_name": "test_ui_filter_accessibility_modes"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_edge_cases",
+			"fully_qualified_name": "tests.core.ui_filter_integration_test.test_ui_filter_edge_cases",
+			"guid": "cbf90917-2ba0449-49d4eb5-d1ff4ceac7",
+			"line_number": 114,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/ui_filter_integration_test.gd",
+			"suite_name": "ui_filter_integration_test",
+			"suite_resource_path": "res://tests/core/ui_filter_integration_test.gd",
+			"test_name": "test_ui_filter_edge_cases"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_restore_all_defaults",
+			"fully_qualified_name": "tests.core.ui_filter_integration_test.test_ui_filter_restore_all_defaults",
+			"guid": "7c02c507-d08c45d-9908956-3004d67337",
+			"line_number": 129,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/ui_filter_integration_test.gd",
+			"suite_name": "ui_filter_integration_test",
+			"suite_resource_path": "res://tests/core/ui_filter_integration_test.gd",
+			"test_name": "test_ui_filter_restore_all_defaults"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_ui_filter_independent_from_theme",
+			"fully_qualified_name": "tests.core.ui_filter_integration_test.test_ui_filter_independent_from_theme",
+			"guid": "870be744-ae7949e-2b3e332-fa72d56e41",
+			"line_number": 145,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/ui_filter_integration_test.gd",
+			"suite_name": "ui_filter_integration_test",
+			"suite_resource_path": "res://tests/core/ui_filter_integration_test.gd",
+			"test_name": "test_ui_filter_independent_from_theme"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_settings_changed_signal_propagation",
+			"fully_qualified_name": "tests.core.ui_filter_integration_test.test_settings_changed_signal_propagation",
+			"guid": "25b4a73a-f3e8464-d9c11f9-6644c78f1c",
+			"line_number": 158,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/ui_filter_integration_test.gd",
+			"suite_name": "ui_filter_integration_test",
+			"suite_resource_path": "res://tests/core/ui_filter_integration_test.gd",
+			"test_name": "test_settings_changed_signal_propagation"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
+			"display_name": "test_no_signal_on_identical_value",
+			"fully_qualified_name": "tests.core.ui_filter_integration_test.test_no_signal_on_identical_value",
+			"guid": "987700ed-d1b344f-cb63d20-3d33586225",
+			"line_number": 170,
+			"metadata": {
+
+			},
+			"require_godot_runtime": true,
+			"source_file": "res://tests/core/ui_filter_integration_test.gd",
+			"suite_name": "ui_filter_integration_test",
+			"suite_resource_path": "res://tests/core/ui_filter_integration_test.gd",
+			"test_name": "test_no_signal_on_identical_value"
+		},
+		{
+			"@path": "res://addons/gdUnit4/src/core/discovery/GdUnitTestCase.gd",
+			"@subpath": "",
+			"assembly_location": "",
+			"attribute_index": -1,
 			"display_name": "test_panel_instantiates_correctly",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_panel_instantiates_correctly",
-			"guid": "7438f302-10f8460-cb41e5f-6e91c5172a",
+			"guid": "0d104ec8-ab27494-e839fb6-db2d3a4814",
 			"line_number": 18,
 			"metadata": {
 
@@ -2546,7 +4130,7 @@
 			"attribute_index": -1,
 			"display_name": "test_has_required_export_variables",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_has_required_export_variables",
-			"guid": "5616b77e-b853449-1b634cd-24d663ef97",
+			"guid": "5bf46c9c-60b6469-bb2d567-b3e9e5d187",
 			"line_number": 22,
 			"metadata": {
 
@@ -2564,7 +4148,7 @@
 			"attribute_index": -1,
 			"display_name": "test_labels_are_correct_type",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_labels_are_correct_type",
-			"guid": "64c04eb2-1b0b4cd-fb3c7d2-379af988ea",
+			"guid": "fbb77647-eecc4bc-f9ea629-adb187d2fa",
 			"line_number": 28,
 			"metadata": {
 
@@ -2582,7 +4166,7 @@
 			"attribute_index": -1,
 			"display_name": "test_buttons_are_correct_type",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_buttons_are_correct_type",
-			"guid": "71bef76d-44f345c-8b0ead2-145050d170",
+			"guid": "f46fd63c-90e64e0-1944ed1-bc0f5b2d6c",
 			"line_number": 32,
 			"metadata": {
 
@@ -2600,7 +4184,7 @@
 			"attribute_index": -1,
 			"display_name": "test_update_sets_line_label_text",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_update_sets_line_label_text",
-			"guid": "6e45086b-9336461-a95e71d-bcd1b1a801",
+			"guid": "ada52ab7-60774c8-48a75ec-8a045f75db",
 			"line_number": 36,
 			"metadata": {
 
@@ -2618,7 +4202,7 @@
 			"attribute_index": -1,
 			"display_name": "test_update_sets_line_label_tooltip",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_update_sets_line_label_tooltip",
-			"guid": "c689ce8b-7f80409-39927dd-94269646e2",
+			"guid": "436f735b-d71b45c-9a37dc6-2726a7fc68",
 			"line_number": 44,
 			"metadata": {
 
@@ -2636,7 +4220,7 @@
 			"attribute_index": -1,
 			"display_name": "test_update_sets_line_number_display",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_update_sets_line_number_display",
-			"guid": "56a9866f-40574ad-f861394-05691e4afa",
+			"guid": "4af44372-8f09429-68ef1d5-4f8b7e1c9c",
 			"line_number": 52,
 			"metadata": {
 
@@ -2654,7 +4238,7 @@
 			"attribute_index": -1,
 			"display_name": "test_update_line_number_zero_indexed",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_update_line_number_zero_indexed",
-			"guid": "fa698c69-1f484d0-fbbb2ef-6cb95c0636",
+			"guid": "fb93de4e-ae9f4a5-9bef87e-4361204752",
 			"line_number": 56,
 			"metadata": {
 
@@ -2672,7 +4256,7 @@
 			"attribute_index": -1,
 			"display_name": "test_update_with_empty_line",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_update_with_empty_line",
-			"guid": "6e10a04b-b4ed407-187a7ba-668df7a3b4",
+			"guid": "002ccbbb-597843c-7bc8aad-31c6fc47c3",
 			"line_number": 69,
 			"metadata": {
 
@@ -2690,7 +4274,7 @@
 			"attribute_index": -1,
 			"display_name": "test_update_with_whitespace_only",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_update_with_whitespace_only",
-			"guid": "ae3ff210-a9134b5-b9593d3-81c93ca778",
+			"guid": "4abe020c-895e423-98e3b88-fa37078d45",
 			"line_number": 75,
 			"metadata": {
 
@@ -2708,7 +4292,7 @@
 			"attribute_index": -1,
 			"display_name": "test_update_with_special_characters",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_update_with_special_characters",
-			"guid": "d20b0dd9-aff9412-0af6242-b1ad8e9bab",
+			"guid": "146b2672-84004a0-d869982-ff2374db8f",
 			"line_number": 81,
 			"metadata": {
 
@@ -2726,7 +4310,7 @@
 			"attribute_index": -1,
 			"display_name": "test_update_with_unicode_characters",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_update_with_unicode_characters",
-			"guid": "ff608e24-ec724c2-68d2292-f035e047f5",
+			"guid": "f3234238-98c9438-29205dd-18eb077665",
 			"line_number": 87,
 			"metadata": {
 
@@ -2744,7 +4328,7 @@
 			"attribute_index": -1,
 			"display_name": "test_update_with_very_long_line",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_update_with_very_long_line",
-			"guid": "e7abcdb3-c3a8444-4a7f48b-18996d0732",
+			"guid": "e59d1803-742c4cb-fb165f1-49bf445581",
 			"line_number": 92,
 			"metadata": {
 
@@ -2762,7 +4346,7 @@
 			"attribute_index": -1,
 			"display_name": "test_update_preserves_line_internal_value",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_update_preserves_line_internal_value",
-			"guid": "845ea26a-d97948f-4b5239a-d490919244",
+			"guid": "967c837d-2d76495-0875d3e-a0511b87bc",
 			"line_number": 98,
 			"metadata": {
 
@@ -2780,7 +4364,7 @@
 			"attribute_index": -1,
 			"display_name": "test_line_property_setter",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_line_property_setter",
-			"guid": "57e3d50c-e5454b0-385f91e-c246f780de",
+			"guid": "309ee9ba-abf747a-0808b86-2f9417adda",
 			"line_number": 102,
 			"metadata": {
 
@@ -2798,7 +4382,7 @@
 			"attribute_index": -1,
 			"display_name": "test_multiple_updates_on_same_panel",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_multiple_updates_on_same_panel",
-			"guid": "db616ee8-b9b5450-88b467b-d1a0f91d6a",
+			"guid": "46031b8d-495c4b3-b9cf0ca-4df6069648",
 			"line_number": 112,
 			"metadata": {
 
@@ -2816,7 +4400,7 @@
 			"attribute_index": -1,
 			"display_name": "test_update_doesnt_affect_button_state",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_update_doesnt_affect_button_state",
-			"guid": "8db102ab-2f2f431-48a0cfd-83b8b434bc",
+			"guid": "a9068455-31b6491-f95f647-5e1dd3c707",
 			"line_number": 128,
 			"metadata": {
 
@@ -2834,7 +4418,7 @@
 			"attribute_index": -1,
 			"display_name": "test_panel_has_theme_type_variation",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_panel_has_theme_type_variation",
-			"guid": "c2940066-f1c4470-686cac9-b01ddcf58f",
+			"guid": "b1d64acc-457c43a-39c103c-6149c08dc1",
 			"line_number": 137,
 			"metadata": {
 
@@ -2852,7 +4436,7 @@
 			"attribute_index": -1,
 			"display_name": "test_goto_button_has_icon",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_goto_button_has_icon",
-			"guid": "75ac3cc8-dda1436-98bb62e-5ccadfcf0b",
+			"guid": "87861c05-952d403-4a20ae2-daa852f5df",
 			"line_number": 141,
 			"metadata": {
 
@@ -2870,7 +4454,7 @@
 			"attribute_index": -1,
 			"display_name": "test_remove_button_has_icon",
 			"fully_qualified_name": "tests.data.panels.bookmarks.item_panel_test.test_remove_button_has_icon",
-			"guid": "c1d18862-98e14a8-68b40e8-8da6e83b63",
+			"guid": "5f4aece8-1592470-48e88c7-4b837051ed",
 			"line_number": 144,
 			"metadata": {
 
@@ -2888,7 +4472,7 @@
 			"attribute_index": -1,
 			"display_name": "test_panel_instantiates_correctly",
 			"fully_qualified_name": "tests.data.panels.bookmarks.panel_test.test_panel_instantiates_correctly",
-			"guid": "17ea55d2-2dde4bd-78d6b38-a10a17e4aa",
+			"guid": "4f12d00f-a1854f7-5ba0492-69eae291ec",
 			"line_number": 18,
 			"metadata": {
 
@@ -2906,7 +4490,7 @@
 			"attribute_index": -1,
 			"display_name": "test_panel_extends_text_forge_panel",
 			"fully_qualified_name": "tests.data.panels.bookmarks.panel_test.test_panel_extends_text_forge_panel",
-			"guid": "ee97e1e4-05a64a1-f85e82a-327949c474",
+			"guid": "859fe2c4-d218435-7935edc-7282030bf7",
 			"line_number": 22,
 			"metadata": {
 
@@ -2924,7 +4508,7 @@
 			"attribute_index": -1,
 			"display_name": "test_has_items_container",
 			"fully_qualified_name": "tests.data.panels.bookmarks.panel_test.test_has_items_container",
-			"guid": "e43ceaab-794b484-f90cb23-a7c16f54ea",
+			"guid": "4e82d7fc-c1e344e-5acf1ff-208ebe8ede",
 			"line_number": 28,
 			"metadata": {
 
@@ -2942,7 +4526,7 @@
 			"attribute_index": -1,
 			"display_name": "test_items_container_starts_empty",
 			"fully_qualified_name": "tests.data.panels.bookmarks.panel_test.test_items_container_starts_empty",
-			"guid": "39ccc415-576845b-38075dd-cc2179f119",
+			"guid": "128ee829-6a154bb-9a08823-675ad13dbe",
 			"line_number": 32,
 			"metadata": {
 
@@ -2960,7 +4544,7 @@
 			"attribute_index": -1,
 			"display_name": "test_has_update_bookmarks_method",
 			"fully_qualified_name": "tests.data.panels.bookmarks.panel_test.test_has_update_bookmarks_method",
-			"guid": "ebf0d7c1-0e42464-bb5dcfa-67c13f77cc",
+			"guid": "57088fe8-30bf453-49ee038-9cdfcadcac",
 			"line_number": 36,
 			"metadata": {
 
@@ -2978,7 +4562,7 @@
 			"attribute_index": -1,
 			"display_name": "test_panel_has_minimum_size",
 			"fully_qualified_name": "tests.data.panels.bookmarks.panel_test.test_panel_has_minimum_size",
-			"guid": "dcbcca12-f7ad418-c941c45-4c63e543d2",
+			"guid": "f0773ed1-d92c4b6-ea7b73c-19b0dae1a1",
 			"line_number": 39,
 			"metadata": {
 
@@ -2996,7 +4580,7 @@
 			"attribute_index": -1,
 			"display_name": "test_margin_container_exists",
 			"fully_qualified_name": "tests.data.panels.bookmarks.panel_test.test_margin_container_exists",
-			"guid": "78ed8a8a-cfdb479-9888148-5c4bbd4276",
+			"guid": "ea61f3ca-3601429-b8b9bdd-fe98f07215",
 			"line_number": 43,
 			"metadata": {
 
@@ -3014,7 +4598,7 @@
 			"attribute_index": -1,
 			"display_name": "test_item_scene_constant_exists",
 			"fully_qualified_name": "tests.data.panels.bookmarks.panel_test.test_item_scene_constant_exists",
-			"guid": "1f88c862-fd53485-5b06f7e-1d60bca7d5",
+			"guid": "4476ff71-b26d4cc-c901cdd-4d8f08b412",
 			"line_number": 52,
 			"metadata": {
 
@@ -3032,7 +4616,7 @@
 			"attribute_index": -1,
 			"display_name": "test_panel_layout_structure",
 			"fully_qualified_name": "tests.data.panels.bookmarks.panel_test.test_panel_layout_structure",
-			"guid": "f733bdf0-8067452-2a85bbb-1d2412a599",
+			"guid": "bab61807-0f964da-4948d31-cca3040ac7",
 			"line_number": 58,
 			"metadata": {
 
@@ -3050,7 +4634,7 @@
 			"attribute_index": -1,
 			"display_name": "test_items_are_in_vbox",
 			"fully_qualified_name": "tests.data.panels.bookmarks.panel_test.test_items_are_in_vbox",
-			"guid": "5a9097b5-a2ea4be-fad564a-eaf130db0a",
+			"guid": "4dae400e-4cc9444-2bcd8ac-cf1ca9c767",
 			"line_number": 62,
 			"metadata": {
 
@@ -3068,7 +4652,7 @@
 			"attribute_index": -1,
 			"display_name": "test_panel_anchors_fill_parent",
 			"fully_qualified_name": "tests.data.panels.bookmarks.panel_test.test_panel_anchors_fill_parent",
-			"guid": "3f28f109-da49434-3b46420-2d5161b5b7",
+			"guid": "3b6836df-b90a47c-0af71b7-0cbdccebbc",
 			"line_number": 66,
 			"metadata": {
 
@@ -3086,7 +4670,7 @@
 			"attribute_index": -1,
 			"display_name": "test_panel_is_visible_by_default",
 			"fully_qualified_name": "tests.data.panels.bookmarks.panel_test.test_panel_is_visible_by_default",
-			"guid": "1dd0f546-8474482-da55a16-4ccc65919b",
+			"guid": "b31771fb-b2e94ab-8832d57-f47083fb1a",
 			"line_number": 76,
 			"metadata": {
 
@@ -3104,7 +4688,7 @@
 			"attribute_index": -1,
 			"display_name": "test_panel_can_be_hidden",
 			"fully_qualified_name": "tests.data.panels.bookmarks.panel_test.test_panel_can_be_hidden",
-			"guid": "59118273-e69244a-c9abd60-dd325ef3fd",
+			"guid": "5e0e1c43-46994b1-9a657fb-fbe461d24d",
 			"line_number": 79,
 			"metadata": {
 
@@ -3122,7 +4706,7 @@
 			"attribute_index": -1,
 			"display_name": "test_panel_can_be_shown",
 			"fully_qualified_name": "tests.data.panels.bookmarks.panel_test.test_panel_can_be_shown",
-			"guid": "f74956ab-070f4a5-a8e316d-165ef55362",
+			"guid": "d33e3879-ce504e5-2b93312-5ef79df6de",
 			"line_number": 83,
 			"metadata": {
 
@@ -3140,7 +4724,7 @@
 			"attribute_index": -1,
 			"display_name": "test_translation_file",
 			"fully_qualified_name": "tests.data.translation_data_test.test_translation_file",
-			"guid": "3bb944f1-69404f9-6a3f0e2-a89c08b6ab",
+			"guid": "4caaa4e5-9fb240e-fa2d903-5d860bacdb",
 			"line_number": 7,
 			"metadata": {
 

--- a/core/autoload/settings.gd
+++ b/core/autoload/settings.gd
@@ -96,6 +96,8 @@ func restore_default(section: String, key: String) -> void:
 
 ## Sets [param velue] for given setting and save settings.
 func set_setting(section: String, key: String, value: Variant = null, force_silent := false) -> void:
+	if get_setting(section, key) == value:
+		return
 	settings.set_value(section, key, value)
 	var err := settings.save(SETTINGS_FILE)
 	if err:

--- a/core/autoload/settings.gd
+++ b/core/autoload/settings.gd
@@ -96,8 +96,9 @@ func restore_default(section: String, key: String) -> void:
 
 ## Sets [param velue] for given setting and save settings.
 func set_setting(section: String, key: String, value: Variant = null, force_silent := false) -> void:
-	if get_setting(section, key) == value:
-		return
+	if settings.has_section_key(section, key):
+		if get_setting(section, key) == value:
+			return
 	settings.set_value(section, key, value)
 	var err := settings.save(SETTINGS_FILE)
 	if err:

--- a/core/autoload/settings.gd
+++ b/core/autoload/settings.gd
@@ -95,7 +95,7 @@ func restore_default(section: String, key: String) -> void:
 
 
 ## Sets [param velue] for given setting and save settings.
-func set_setting(section: String, key: String, value: Variant = null) -> void:
+func set_setting(section: String, key: String, value: Variant = null, force_silent := false) -> void:
 	settings.set_value(section, key, value)
 	var err := settings.save(SETTINGS_FILE)
 	if err:
@@ -104,6 +104,9 @@ func set_setting(section: String, key: String, value: Variant = null) -> void:
 			"Can't save settings file!",
 			"Error code: " + str(err)
 		)
+		return
+	if not force_silent:
+		Signals.settings_changed.emit()
 
 
 ## Defines new preset, it means this preset will have default value ([param default]) and can reset

--- a/core/main.gd
+++ b/core/main.gd
@@ -43,6 +43,8 @@ const MENU_TRANSLATION_PREFIX = "menu."
 @export var module_profiler: MenuButton
 ## [ReplacePopup] for template completion.
 @export var replace_popup: ReplacePopup
+## Overlay to apply shader filter.
+@export var overlay_shader: ColorRect
 
 ## Recent files [PopupMenu], see also [method _reload_recent_files].
 var recent_files_submenu: PopupMenu
@@ -116,6 +118,10 @@ func _define_presets() -> void:
 	Settings.define_preset("edit", "indent_size", 4)
 	# 3. Theme
 	Settings.define_preset("editor_ui", "theme_name", "dark")
+	# 4. UI Filter
+	Settings.define_preset("editor_ui", "filter_hue_shift", 0.0)
+	Settings.define_preset("editor_ui", "filter_saturation", 1.0)
+	Settings.define_preset("editor_ui", "filter_brightness", 1.0)
 
 
 ## Loads core-related settings. This function supports dynamic reload for mode, theme, and indentation.
@@ -133,14 +139,17 @@ func _handle_settings() -> void:
 	if not FileAccess.file_exists(S.TEMPLATE_THEME.format([Settings.get_setting("editor_ui", "theme_name")])):
 		Settings.restore_default("editor_ui", "theme_name")
 	get_window().set_theme(U.load_resource(S.TEMPLATE_THEME.format([Settings.get_setting("editor_ui", "theme_name")])))
-	# Dynamic reload
-	# 1. Mode reload
+	# 3. Mode reload
 	var current_mode := Global.get_editor_api().current_mode
 	if current_mode:
 		Global.get_editor_api()._unload_current_mode()
 		await U.wait()
 		Global.get_editor_api()._change_mode_to(current_mode)
 	_is_reloading_settings = false
+	# 4. UI Filter
+	overlay_shader.material.set_shader_parameter("hue_shift", Settings.get_setting("editor_ui", "filter_hue_shift"))
+	overlay_shader.material.set_shader_parameter("saturation", Settings.get_setting("editor_ui", "filter_saturation"))
+	overlay_shader.material.set_shader_parameter("brightness", Settings.get_setting("editor_ui", "filter_brightness"))
 
 
 ## Loads data in [member main_menu_data], uses [constant S.MAIN_UI_DATA] and [constant DATA_SECTION].

--- a/core/main.gdshader
+++ b/core/main.gdshader
@@ -1,0 +1,38 @@
+shader_type canvas_item;
+
+uniform sampler2D SCREEN_TEXTURE : hint_screen_texture, filter_linear_mipmap;
+
+uniform float hue_shift : hint_range(-1.0, 1.0);   // تغییر Hue
+uniform float saturation : hint_range(0.0, 2.0) = 1.0; // تغییر Saturation
+uniform float brightness : hint_range(0.0, 2.0) = 1.0; // تغییر Brightness
+
+vec3 rgb2hsv(vec3 c) {
+    vec4 K = vec4(0.0, -1.0/3.0, 2.0/3.0, -1.0);
+    vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+    vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+
+    float d = q.x - min(q.w, q.y);
+    float e = 1.0e-10;
+    return vec3(abs(q.z + (q.w - q.y) / (6.0*d + e)),
+                d / (q.x + e),
+                q.x);
+}
+
+vec3 hsv2rgb(vec3 c) {
+    vec3 rgb = clamp( abs(mod(c.x*6.0 + vec3(0.0,4.0,2.0), 6.0) - 3.0) - 1.0,
+                      0.0,
+                      1.0 );
+    return c.z * mix(vec3(1.0), rgb, c.y);
+}
+
+void fragment() {
+    vec4 col = texture(SCREEN_TEXTURE, SCREEN_UV);
+
+    vec3 hsv = rgb2hsv(col.rgb);
+    hsv.x = fract(hsv.x + hue_shift);   // تغییر Hue
+    hsv.y *= saturation;                // تغییر Saturation
+    hsv.z *= brightness;                // تغییر Brightness
+
+    vec3 new_rgb = hsv2rgb(hsv);
+    COLOR = vec4(new_rgb, col.a);
+}

--- a/core/main.gdshader.uid
+++ b/core/main.gdshader.uid
@@ -1,0 +1,1 @@
+uid://d4lcsig5si0bn

--- a/core/main.tscn
+++ b/core/main.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=21 format=3 uid="uid://dx1alvj3tjt16"]
+[gd_scene load_steps=23 format=3 uid="uid://dx1alvj3tjt16"]
 
 [ext_resource type="Script" uid="uid://byayvu15ojy1j" path="res://core/main.gd" id="1_o5qli"]
 [ext_resource type="Script" uid="uid://bkd665ctfsj35" path="res://core/scripts/replace_popup.gd" id="2_g0q11"]
+[ext_resource type="Shader" uid="uid://d4lcsig5si0bn" path="res://core/main.gdshader" id="2_i2u5h"]
 [ext_resource type="Texture2D" uid="uid://cbmkrx1vn2jtp" path="res://assets/close.svg" id="2_ntwa4"]
 [ext_resource type="Script" uid="uid://dfy2sbtb4i0ht" path="res://core/scripts/panel_manager.gd" id="2_tefeu"]
 [ext_resource type="Texture2D" uid="uid://f7lveaepk802" path="res://assets/down.svg" id="3_lxu0y"]
@@ -20,10 +21,16 @@
 [ext_resource type="Script" uid="uid://812j1a3e2eym" path="res://core/scripts/caret_pos.gd" id="10_7ua4h"]
 [ext_resource type="Script" uid="uid://c4e2vkjgt6lwi" path="res://core/scripts/indentation_settings_label.gd" id="13_slld4"]
 
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_7akvt"]
+shader = ExtResource("2_i2u5h")
+shader_parameter/hue_shift = 0.0
+shader_parameter/saturation = 1.0
+shader_parameter/brightness = 1.0
+
 [sub_resource type="Theme" id="Theme_csopv"]
 Button/colors/font_color = Color(0.87451, 0.87451, 0.87451, 0.607843)
 
-[node name="Main" type="Control" node_paths=PackedStringArray("menu_container", "file_label", "editor", "scripts", "panel_manager", "about", "module_profiler", "replace_popup")]
+[node name="Main" type="Control" node_paths=PackedStringArray("menu_container", "file_label", "editor", "scripts", "panel_manager", "about", "module_profiler", "replace_popup", "overlay_shader")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -39,6 +46,19 @@ panel_manager = NodePath("Margin/Sections/PanelManager")
 about = NodePath("About")
 module_profiler = NodePath("Margin/Sections/BottomBar/ModuleProfiler")
 replace_popup = NodePath("Overlays/Replace popup")
+overlay_shader = NodePath("UIFilter/OverlayShader")
+
+[node name="UIFilter" type="CanvasLayer" parent="."]
+layer = 3
+
+[node name="OverlayShader" type="ColorRect" parent="UIFilter"]
+material = SubResource("ShaderMaterial_7akvt")
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
 
 [node name="Overlays" type="CanvasLayer" parent="."]
 layer = 2

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -93,12 +93,12 @@ To automatically save files when moving between project files, enable
 
 ## Customize Editor Appearance
 
-You can customize editor appearance in multilpe ways:
+You can customize editor appearance in multiple ways:
 
 ### Using Themes
 
 To find a theme, open `Settings > Marketplace` and set package filter to `Themes`. You can click on
-a theme and see its preview and them install it with **Install** button. When theme downloaded and
+a theme and see its preview and then install it with **Install** button. When theme downloaded and
 installed, you will see a confirmation dialog that says you can enable this theme now. Next time,
 you can open `Settings > Preferences` and go to `Editor UI > Theme` to change theme. If you want to
 see where themes are installed use `Settings > Open Data Folder` and go to `themes/` folder.
@@ -109,4 +109,4 @@ Sometimes you need to change editor appearance just to more brightness or less s
 situations you can use **UI Filter** a feature to apply customizations in a few moments. To see how
 it works, open `Settings > Preferences` and go to `Editor UI` in this section you can find three
 options: `Filter Hue Shift`, `Filter Saturation`, and `Filter Brightness`. With this feature you can
-customize editors appearance to any base color, saturation ans brightness and see result dynamicly.
+customize editors appearance to any base color, saturation and brightness and see result dynamically.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -90,3 +90,23 @@ To automatically save files when moving between project files, enable
 
 !!! Tip
     See also: [Project menu](menus.md#project)
+
+## Customize Editor Appearance
+
+You can customize editor appearance in multilpe ways:
+
+### Using Themes
+
+To find a theme, open `Settings > Marketplace` and set package filter to `Themes`. You can click on
+a theme and see its preview and them install it with **Install** button. When theme downloaded and
+installed, you will see a confirmation dialog that says you can enable this theme now. Next time,
+you can open `Settings > Preferences` and go to `Editor UI > Theme` to change theme. If you want to
+see where themes are installed use `Settings > Open Data Folder` and go to `themes/` folder.
+
+### UI Filter
+
+Sometimes you need to change editor appearance just to more brightness or less saturation, in this
+situations you can use **UI Filter** a feature to apply customizations in a few moments. To see how
+it works, open `Settings > Preferences` and go to `Editor UI` in this section you can find three
+options: `Filter Hue Shift`, `Filter Saturation`, and `Filter Brightness`. With this feature you can
+customize editors appearance to any base color, saturation ans brightness and see result dynamicly.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -98,14 +98,14 @@ You can customize editor appearance in multiple ways:
 ### Using Themes
 
 To find a theme, open `Settings > Marketplace` and set package filter to `Themes`. You can click on
-a theme and see its preview and then install it with **Install** button. When theme downloaded and
-installed, you will see a confirmation dialog that says you can enable this theme now. Next time,
+a theme and see its preview and them install it with **Install** button. When the theme is downloaded
+and installed, you will see a confirmation dialog that says you can enable this theme now. Next time,
 you can open `Settings > Preferences` and go to `Editor UI > Theme` to change theme. If you want to
 see where themes are installed use `Settings > Open Data Folder` and go to `themes/` folder.
 
 ### UI Filter
 
-Sometimes you need to change editor appearance just to more brightness or less saturation, in this
+Sometimes you need to change editor appearance just to add more brightness or less saturation, in this
 situations you can use **UI Filter** a feature to apply customizations in a few moments. To see how
 it works, open `Settings > Preferences` and go to `Editor UI` in this section you can find three
 options: `Filter Hue Shift`, `Filter Saturation`, and `Filter Brightness`. With this feature you can

--- a/tests/INDEX.md
+++ b/tests/INDEX.md
@@ -15,26 +15,26 @@
 ## Unit Tests
 
 - Path: `tests/`
-- Tests: 175
-- Files: 13
+- Tests: 263
+- Files: 19
 
 ### Action Scripts Tests
 
 - Path: `tests/action_scripts/`
-- Tests: 19
-- Files: 2
+- Tests: 52
+- Files: 5
 
 ### Autoloads Tests
 
 - Path: `tests/core/autoload/`
-- Tests: 93
+- Tests: 103
 - Files: 6
 
 ### Core Tests
 
 - Path: `tests/core/`
-- Tests: 28
-- Files: 2
+- Tests: 73
+- Files: 5
 
 ### Data Tests
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,7 +9,7 @@ This directory contains comprehensive unit tests for the Text Forge text editor.
 
 ## Performance Benchmarks
 Current test suite execution time (estimated):
-- **All tests**: ~13 seconds
+- **All tests**: ~20 seconds
 - **Individual file**: ~1 second
 
 ## Test Generation Notes
@@ -25,6 +25,36 @@ Current test suite execution time (estimated):
   - Complex states like multi-caret edit
   - Parse error handling
   - Execute error handling
+- Don't use local variables in lambda functions, use like this (`test_neme__var_name`):
+```
+# GdUnit generated TestSuite
+class_name UIFilterIntegrationTestSuite
+extends GdUnitTestSuite
+@warning_ignore('unused_parameter')
+@warning_ignore('return_value_discarded')
+
+...
+
+var test_complete_ui_filter_workflow__signal_emitted := false
+
+...
+
+func test_complete_ui_filter_workflow() -> void:
+	# Test complete workflow: setting -> signal -> reload
+	var connection := func(): test_complete_ui_filter_workflow__signal_emitted = true
+	Signals.settings_changed.connect(connection)
+
+	# Change hue shift
+	Settings.set_setting(test_section, "filter_hue_shift", 0.5)
+	await get_tree().process_frame
+	assert_bool(test_complete_ui_filter_workflow__signal_emitted).is_true()
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_equal(0.5)
+
+	Signals.settings_changed.disconnect(connection)
+
+...
+
+```
 
 ### Best Practices
 1. **One Test Per Behavior**: Each test should verify one specific behavior

--- a/tests/TEST_SUMMARY.md
+++ b/tests/TEST_SUMMARY.md
@@ -6,38 +6,41 @@ project changes.
 
 ## Test Results
 
-- **Overall:** 175 test cases | 0 errors | 0 failures | 0 flaky | 0 skipped | 0 orphans (6/6 🟢)
-- **Executed test suites:** (13/13)
-- **Executed test cases :** (175/175)
-- **Total execution time:** 13s 70ms
+- **Overall:** 263 test cases | 0 errors | 0 failures | 0 flaky | 0 skipped | 0 orphans (6/6 🟢)
+- **Executed test suites:** (19/19)
+- **Executed test cases :** (263/263)
+- **Total execution time:** 21s 817ms
 - **Runner:** GDUnit4 6.0.1
 
 ## Test Files
 
-- Unit Tests: 175
-- Files: 13
+- Unit Tests: 263
+- Files: 19
 
 ### Action Scripts Tests
 
 - Path: `tests/action_scripts/`
-- Tests: 19
+- Tests: 52
 
 |        Test File         | Tests | Lines |        Covers                 | Coverage |
 |:------------------------:|:-----:|:-----:|:-----------------------------:|:--------:|
 | `action_scripts_test.gd` |   15  |  96   | Class, Loading, Functionality | ⭐⭐⭐⭐ |
 |      `close_test.gd`     |   4   |  41   |     Class, Initialization     | ⭐⭐⭐⭐ |
+| `scenes/marketplace_test.gd` | 5 |  100  |        Dynamic reload         | ⭐ |
+| `scenes/preferences_test.gd` | 9 |  94   |    Initialization, Behavior   | ⭐⭐⭐ |
+| `scenes/setting_option_test.gd` | 19 | 209 | Initialization, Type check, Behavior, Signals | ⭐⭐⭐⭐⭐ |
 
 ### Autoloads Tests
 
 - Path: `tests/core/autoload/`
-- Tests: 93
+- Tests: 103
 
 |           Test File           | Tests | Lines |                         Covers                          | Coverage |
 |:-----------------------------:|:-----:|:-----:|:-------------------------------------------------------:|:--------:|
 |     `backup_core_test.gd`     |   14  |  87   |          Creation, Restoration, Configuration           | ⭐⭐⭐⭐⭐ |
 |       `factory_test.gd`       |   4   |  44   |                      Node creation                      | ⭐⭐ |
 |       `global_test.gd`        |   26  |  140  |    Access, File management, Commands, Notifications     | ⭐⭐⭐⭐⭐ |
-|       `settings_test.gd`      |   21  |  122  |    Configuration management, Presets, Data storage      | ⭐⭐⭐⭐⭐ |
+|       `settings_test.gd`      |   31  |  270  |    Configuration management, Presets, Data storage      | ⭐⭐⭐⭐⭐ |
 | `translation_manager_test.gd` |   7   |  47   |              Translation, Language change               | ⭐⭐⭐⭐ |
 |        `utils_test.gd`        |   21  |  107  | Syntax colors, Wait, Resource loading, Threaded loading | ⭐⭐⭐⭐ |
 

--- a/tests/action_scripts/scenes/marketplace_test.gd
+++ b/tests/action_scripts/scenes/marketplace_test.gd
@@ -1,0 +1,99 @@
+# GdUnit generated TestSuite
+class_name MarketplaceTestSuite
+extends GdUnitTestSuite
+@warning_ignore('unused_parameter')
+@warning_ignore('return_value_discarded')
+
+# TestSuite for marketplace.gd signal emission behavior
+const __source = 'res://action_scripts/scenes/marketplace.gd'
+
+var test_section := "editor_ui"
+var test_key := "theme_name"
+
+var test_change_theme_triggers_settings_changed_signal__signal_emitted := false
+var test_change_theme_no_duplicate_signal__signal_count := 0
+var test_theme_setting_with_same_value_no_signal__signal_emitted := false
+
+func before_test() -> void:
+	# Store original theme
+	pass
+
+func after_test() -> void:
+	# Restore original theme if needed
+	if Settings.presets.has_section_key(test_section, test_key):
+		Settings.restore_default(test_section, test_key)
+
+func test_change_theme_updates_setting() -> void:
+	# Simulate theme change
+	var original_theme = Settings.get_setting(test_section, test_key)
+
+	# The _change_theme method should call Settings.set_setting
+	# which will automatically emit settings_changed signal
+	Settings.set_setting(test_section, test_key, "test_theme")
+
+	assert_str(Settings.get_setting(test_section, test_key)).is_equal("test_theme")
+
+	# Restore
+	Settings.set_setting(test_section, test_key, original_theme)
+
+func test_change_theme_triggers_settings_changed_signal() -> void:
+	# Verify that changing theme emits settings_changed signal
+	# through Settings.set_setting, not manually
+	var original_theme = Settings.get_setting(test_section, test_key)
+	var connection := func(): test_change_theme_triggers_settings_changed_signal__signal_emitted = true
+	Signals.settings_changed.connect(connection)
+
+	# Change theme
+	Settings.set_setting(test_section, test_key, "new_theme")
+	await get_tree().process_frame
+
+	# Signal should be emitted by Settings.set_setting
+	assert_bool(test_change_theme_triggers_settings_changed_signal__signal_emitted).is_true()
+
+	# Restore
+	Signals.settings_changed.disconnect(connection)
+	Settings.set_setting(test_section, test_key, original_theme)
+
+func test_change_theme_no_duplicate_signal() -> void:
+	# Test that changing theme doesn't emit signal twice
+	# (once manually, once from Settings.set_setting)
+	var original_theme = Settings.get_setting(test_section, test_key)
+	var connection := func(): test_change_theme_no_duplicate_signal__signal_count += 1
+	Signals.settings_changed.connect(connection)
+
+	# Change theme
+	Settings.set_setting(test_section, test_key, "another_theme")
+	await get_tree().process_frame
+
+	# Should only be emitted once (by Settings.set_setting)
+	assert_int(test_change_theme_no_duplicate_signal__signal_count).is_equal(1)
+
+	# Restore
+	Signals.settings_changed.disconnect(connection)
+	Settings.set_setting(test_section, test_key, original_theme)
+
+func test_settings_api_handles_theme_change() -> void:
+	# Document that Settings API is responsible for signal emission
+	var original_theme = Settings.get_setting(test_section, test_key)
+
+	# Set a new theme
+	Settings.set_setting(test_section, test_key, "dark")
+	assert_str(Settings.get_setting(test_section, test_key)).is_equal("dark")
+
+	# Restore
+	Settings.set_setting(test_section, test_key, original_theme)
+
+func test_theme_setting_with_same_value_no_signal() -> void:
+	# Test that setting same theme doesn't emit signal (early return)
+	var current_theme = Settings.get_setting(test_section, test_key)
+	var connection := func(): test_theme_setting_with_same_value_no_signal__signal_emitted = true
+	Signals.settings_changed.connect(connection)
+
+	# Set same theme
+	Settings.set_setting(test_section, test_key, current_theme)
+	await get_tree().process_frame
+
+	# No signal should be emitted due to early return
+	assert_bool(test_theme_setting_with_same_value_no_signal__signal_emitted).is_false()
+
+	Signals.settings_changed.disconnect(connection)

--- a/tests/action_scripts/scenes/marketplace_test.gd.uid
+++ b/tests/action_scripts/scenes/marketplace_test.gd.uid
@@ -1,0 +1,1 @@
+uid://bdspaikhhqxos

--- a/tests/action_scripts/scenes/preferences_test.gd
+++ b/tests/action_scripts/scenes/preferences_test.gd
@@ -1,0 +1,93 @@
+# GdUnit generated TestSuite
+class_name PreferencesWindowTestSuite
+extends GdUnitTestSuite
+@warning_ignore('unused_parameter')
+@warning_ignore('return_value_discarded')
+
+# TestSuite generated from
+const __source = 'res://action_scripts/scenes/preferences.gd'
+
+var preferences_window: PreferencesWindow
+
+var test_preferences_window_no_manual_signal_emission__signal_count := 0
+
+func before_test() -> void:
+	preferences_window = auto_free(load(__source.replace(".gd", ".tscn")).instantiate())
+	add_child(preferences_window)
+
+func test_preferences_window_initializes() -> void:
+	assert_object(preferences_window).is_not_null()
+	assert_object(preferences_window).is_instanceof(PreferencesWindow)
+
+func test_container_exists() -> void:
+	assert_object(preferences_window.container).is_not_null()
+	assert_object(preferences_window.container).is_instanceof(TabContainer)
+
+func test_tree_exists() -> void:
+	assert_object(preferences_window.tree).is_not_null()
+	assert_object(preferences_window.tree).is_instanceof(Tree)
+
+func test_close_requested_signal_connected() -> void:
+	# Verify close_requested signal is connected to queue_free
+	var connections = preferences_window.close_requested.get_connections()
+	var has_queue_free := false
+	for conn in connections:
+		if conn["callable"].get_method() == "queue_free":
+			has_queue_free = true
+			break
+	assert_bool(has_queue_free).is_true()
+
+func test_preferences_window_no_manual_signal_emission() -> void:
+	# This test verifies that closing the window doesn't manually emit settings_changed
+	# The signal should only be emitted by Settings.set_setting
+	var connection := func(): test_preferences_window_no_manual_signal_emission__signal_count += 1
+	Signals.settings_changed.connect(connection)
+
+	# Simulate window close
+	preferences_window.close_requested.emit()
+	await get_tree().process_frame
+
+	# No signal should be emitted just from closing
+	assert_int(test_preferences_window_no_manual_signal_emission__signal_count).is_equal(0)
+	Signals.settings_changed.disconnect(connection)
+
+func test_preferences_loads_settings_from_presets() -> void:
+	# Verify preferences window loads from presets file
+	preferences_window._ready()
+	await get_tree().process_frame
+
+	# Should have created tabs based on presets
+	assert_int(preferences_window.container.get_child_count()).is_greater(0)
+
+func test_setting_sections_created() -> void:
+	preferences_window._ready()
+	await get_tree().process_frame
+
+	# Verify sections are created
+	var tree_root = preferences_window.tree.get_root()
+	assert_object(tree_root).is_not_null()
+	assert_int(tree_root.get_child_count()).is_greater(0)
+
+func test_empty_sections_removed() -> void:
+	preferences_window._ready()
+	await get_tree().process_frame
+
+	# Empty sections should be removed (no items)
+	# We can't easily test this without mocking, but we verify the logic exists
+	# by checking that sections with items are kept
+	for child in preferences_window.container.get_children():
+		if child is ScrollContainer:
+			var vbox = child.get_child(0)
+			# If section exists, it should have at least one child
+			assert_int(vbox.get_child_count()).is_greater_equal(0)
+
+func test_section_names_capitalized() -> void:
+	preferences_window._ready()
+	await get_tree().process_frame
+
+	# Check that section names are properly capitalized
+	for child in preferences_window.container.get_children():
+		var child_name = child.name
+		# Should be capitalized and handle "UI" specially
+		if "ui" in child_name.to_lower():
+			assert_bool(child_name.contains("UI")).is_true()

--- a/tests/action_scripts/scenes/preferences_test.gd.uid
+++ b/tests/action_scripts/scenes/preferences_test.gd.uid
@@ -1,0 +1,1 @@
+uid://bgnh6qlarbc4i

--- a/tests/action_scripts/scenes/setting_option_test.gd
+++ b/tests/action_scripts/scenes/setting_option_test.gd
@@ -1,0 +1,208 @@
+# GdUnit generated TestSuite
+class_name SettingOptionTestSuite
+extends GdUnitTestSuite
+@warning_ignore('unused_parameter')
+@warning_ignore('return_value_discarded')
+
+# TestSuite generated from
+const __source = 'res://action_scripts/scenes/setting_option.gd'
+
+var setting_option: SettingOption
+var test_section := "test_ui"
+var test_key := "test_setting"
+
+func before_test() -> void:
+	# Clean up test settings
+	if Settings.settings.has_section(test_section):
+		Settings.settings.erase_section(test_section)
+	if Settings.presets.has_section(test_section):
+		Settings.presets.erase_section(test_section)
+
+	# Create a new SettingOption instance
+	setting_option = load(__source.replace(".gd", ".tscn")).instantiate()
+	add_child(setting_option)
+
+func after_test() -> void:
+	# Clean up
+	if Settings.settings.has_section(test_section):
+		Settings.settings.erase_section(test_section)
+	if Settings.presets.has_section(test_section):
+		Settings.presets.erase_section(test_section)
+
+func test_setting_option_initializes() -> void:
+	assert_object(setting_option).is_not_null()
+	assert_object(setting_option).is_instanceof(SettingOption)
+
+func test_label_exists() -> void:
+	assert_object(setting_option.label).is_not_null()
+	assert_object(setting_option.label).is_instanceof(Label)
+
+func test_options_tab_container_exists() -> void:
+	assert_object(setting_option.options).is_not_null()
+	assert_object(setting_option.options).is_instanceof(TabContainer)
+
+func test_bool_setting_displays_correctly() -> void:
+	Settings.define_preset(test_section, test_key, true)
+	setting_option.section = test_section
+	setting_option.key = test_key
+	setting_option._ready()
+
+	# Should select checkbox tab (index 0)
+	assert_int(setting_option.options.current_tab).is_equal(0)
+	assert_bool(setting_option.options.get_child(0).button_pressed).is_true()
+
+func test_bool_setting_false_displays_off() -> void:
+	Settings.define_preset(test_section, test_key, false)
+	setting_option.section = test_section
+	setting_option.key = test_key
+	setting_option._ready()
+
+	assert_int(setting_option.options.current_tab).is_equal(0)
+	assert_bool(setting_option.options.get_child(0).button_pressed).is_false()
+	assert_str(setting_option.options.get_child(0).text).is_equal("Off")
+
+func test_int_setting_displays_correctly() -> void:
+	Settings.define_preset(test_section, test_key, 42)
+	setting_option.section = test_section
+	setting_option.key = test_key
+	setting_option._ready()
+
+	# Should select SpinBox tab (index 1)
+	assert_int(setting_option.options.current_tab).is_equal(1)
+	assert_float(setting_option.options.get_child(1).value).is_equal(42.0)
+
+func test_float_setting_displays_correctly() -> void:
+	Settings.define_preset(test_section, test_key, 3.14)
+	setting_option.section = test_section
+	setting_option.key = test_key
+	setting_option._ready()
+
+	# Should select SpinBox tab (index 1) for floats
+	assert_int(setting_option.options.current_tab).is_equal(1)
+	assert_float(setting_option.options.get_child(1).value).is_equal(3.14)
+
+func test_float_setting_with_zero() -> void:
+	Settings.define_preset(test_section, test_key, 0.0)
+	setting_option.section = test_section
+	setting_option.key = test_key
+	setting_option._ready()
+
+	assert_int(setting_option.options.current_tab).is_equal(1)
+	assert_float(setting_option.options.get_child(1).value).is_equal(0.0)
+
+func test_float_setting_with_negative_value() -> void:
+	Settings.define_preset(test_section, test_key, -1.5)
+	setting_option.section = test_section
+	setting_option.key = test_key
+	setting_option._ready()
+
+	assert_int(setting_option.options.current_tab).is_equal(1)
+	assert_float(setting_option.options.get_child(1).value).is_equal(-1.5)
+
+func test_float_setting_with_large_value() -> void:
+	Settings.define_preset(test_section, test_key, 999.99)
+	setting_option.section = test_section
+	setting_option.key = test_key
+	setting_option._ready()
+
+	assert_int(setting_option.options.current_tab).is_equal(1)
+	assert_float(setting_option.options.get_child(1).value).is_equal(999.99)
+
+func test_string_setting_displays_correctly() -> void:
+	Settings.define_preset(test_section, test_key, "test_string")
+	setting_option.section = test_section
+	setting_option.key = test_key
+	setting_option._ready()
+
+	# Should select LineEdit tab (index 2)
+	assert_int(setting_option.options.current_tab).is_equal(2)
+	assert_str(setting_option.options.get_child(2).text).is_equal("test_string")
+
+func test_array_setting_displays_correctly() -> void:
+	Settings.define_preset(test_section, test_key, ["item1", "item2", "item3"])
+	setting_option.section = test_section
+	setting_option.key = test_key
+	setting_option._ready()
+
+	# Should select LineEdit2 tab (index 3) for arrays
+	assert_int(setting_option.options.current_tab).is_equal(3)
+	assert_str(setting_option.options.get_child(3).text).is_equal("item1, item2, item3")
+
+func test_label_text_capitalized() -> void:
+	setting_option.section = test_section
+	setting_option.key = "test_key_name"
+	Settings.define_preset(test_section, "test_key_name", 0)
+	setting_option._ready()
+
+	assert_str(setting_option.label.text).is_equal("Test Key Name")
+
+func test_checkbox_toggle_updates_setting() -> void:
+	Settings.define_preset(test_section, test_key, false)
+	setting_option.section = test_section
+	setting_option.key = test_key
+	setting_option._ready()
+
+	# Simulate checkbox press
+	setting_option.options.get_child(0).button_pressed = true
+	setting_option._on_check_box_pressed()
+
+	assert_bool(Settings.get_setting(test_section, test_key)).is_true()
+	assert_str(setting_option.options.get_child(0).text).is_equal("On")
+
+func test_spinbox_change_updates_int_setting() -> void:
+	Settings.define_preset(test_section, test_key, 10)
+	setting_option.section = test_section
+	setting_option.key = test_key
+	setting_option._ready()
+
+	# Simulate SpinBox value change
+	setting_option.options.get_child(1).value = 25
+	setting_option._on_spin_box_value_changed()
+
+	assert_float(Settings.get_setting(test_section, test_key)).is_equal(25.0)
+
+func test_line_edit_change_updates_string_setting() -> void:
+	Settings.define_preset(test_section, test_key, "initial")
+	setting_option.section = test_section
+	setting_option.key = test_key
+	setting_option._ready()
+
+	# Simulate LineEdit text submission
+	setting_option._on_line_edit_text_submitted("updated_text")
+
+	assert_str(Settings.get_setting(test_section, test_key)).is_equal("updated_text")
+
+func test_line_edit2_change_updates_array_setting() -> void:
+	Settings.define_preset(test_section, test_key, [])
+	setting_option.section = test_section
+	setting_option.key = test_key
+	setting_option._ready()
+
+	# Simulate LineEdit2 text submission with comma-separated values
+	setting_option._on_line_edit_2_text_submitted("a, b, c")
+
+	var result = Settings.get_setting(test_section, test_key)
+	assert_array(result).contains_exactly(["a", "b", "c"])
+
+func test_array_setting_strips_whitespace() -> void:
+	Settings.define_preset(test_section, test_key, [])
+	setting_option.section = test_section
+	setting_option.key = test_key
+	setting_option._ready()
+
+	# Submit with extra whitespace
+	setting_option._on_line_edit_2_text_submitted("  item1  ,  item2  ,  item3  ")
+
+	var result = Settings.get_setting(test_section, test_key)
+	assert_array(result).contains_exactly(["item1", "item2", "item3"])
+
+func test_invalid_type_queues_free() -> void:
+	# Dictionary type is not supported
+	Settings.define_preset(test_section, test_key, {"key": "value"})
+	setting_option.section = test_section
+	setting_option.key = test_key
+	setting_option._ready()
+
+	await await_idle_frame()
+
+	assert_object(setting_option).is_null()

--- a/tests/action_scripts/scenes/setting_option_test.gd.uid
+++ b/tests/action_scripts/scenes/setting_option_test.gd.uid
@@ -1,0 +1,1 @@
+uid://byntl7v8ccpoj

--- a/tests/core/autoload/backup_core_test.gd
+++ b/tests/core/autoload/backup_core_test.gd
@@ -78,7 +78,7 @@ func test_auto_backup_default_enabled() -> void:
 	assert_bool(auto_backup is bool).is_true()
 
 func test_backup_interval_default_value() -> void:
-	var interval = Settings.get_setting("files", "auto_backup_interval_minutes")
+	var interval: int = Settings.get_setting("files", "auto_backup_interval_minutes")
 	assert_int(interval).is_equal(5)
 
 func test_keep_backup_days_default_value() -> void:

--- a/tests/core/autoload/settings_test.gd
+++ b/tests/core/autoload/settings_test.gd
@@ -10,6 +10,16 @@ const __source = 'res://core/autoload/settings.gd'
 var test_section := "test_section"
 var test_key := "test_key"
 
+var test_set_setting_early_return_when_value_unchanged__signal_emitted := false
+var test_set_setting_emits_signal_on_value_change__signal_emitted := false
+var test_set_setting_force_silent_suppresses_signal__signal_emitted := false
+var test_set_setting_force_silent_false_emits_signal__signal_emitted := false
+var test_set_setting_early_return_with_same_numeric_value__signal_emitted := false
+var test_set_setting_early_return_with_same_boolean_value__signal_emitted := false
+var test_set_setting_early_return_with_same_float_value__signal_emitted := false
+var test_restore_default_emits_settings_changed__signal_emitted := false
+var test_restore_default_no_signal_if_already_default__signal_emitted := false
+
 func before_test() -> void:
 	# Clean up test data before each test
 	if Settings.settings.has_section(test_section):
@@ -123,3 +133,137 @@ func test_globalize_path_converts_user_path() -> void:
 func test_globalize_path_handles_res_path() -> void:
 	var path = S.globalize_path("res://icon.png")
 	assert_bool(path.contains("icon.png")).is_true()
+
+# Tests for enhanced set_setting functionality (PR #145)
+
+func test_set_setting_early_return_when_value_unchanged() -> void:
+	# Set initial value
+	Settings.define_preset(test_section, test_key, "initial_value")
+	Settings.set_setting(test_section, test_key, "test_value")
+
+	# Create a signal spy to verify settings_changed is not emitted
+	var connection := func(): test_set_setting_early_return_when_value_unchanged__signal_emitted = true
+	Signals.settings_changed.connect(connection)
+
+	# Set same value again - should return early without emitting signal
+	Settings.set_setting(test_section, test_key, "test_value")
+	await get_tree().process_frame
+
+	assert_bool(test_set_setting_early_return_when_value_unchanged__signal_emitted).is_false()
+	Signals.settings_changed.disconnect(connection)
+
+func test_set_setting_emits_signal_on_value_change() -> void:
+	# Set initial value
+	Settings.set_setting(test_section, test_key, "initial_value")
+
+	# Create a signal spy
+	var connection := func(): test_set_setting_emits_signal_on_value_change__signal_emitted = true
+	Signals.settings_changed.connect(connection)
+
+	# Change value - should emit signal
+	Settings.set_setting(test_section, test_key, "new_value")
+	await get_tree().process_frame
+
+	assert_bool(test_set_setting_emits_signal_on_value_change__signal_emitted).is_true()
+	Signals.settings_changed.disconnect(connection)
+
+func test_set_setting_force_silent_suppresses_signal() -> void:
+	# Set initial value
+	Settings.set_setting(test_section, test_key, "initial_value")
+
+	# Create a signal spy
+	var connection := func(): test_set_setting_force_silent_suppresses_signal__signal_emitted = true
+	Signals.settings_changed.connect(connection)
+
+	# Change value with force_silent = true
+	Settings.set_setting(test_section, test_key, "silent_change", true)
+	await get_tree().process_frame
+
+	# Signal should not be emitted
+	assert_bool(test_set_setting_force_silent_suppresses_signal__signal_emitted).is_false()
+	# But value should still be changed
+	assert_str(Settings.get_setting(test_section, test_key)).is_equal("silent_change")
+	Signals.settings_changed.disconnect(connection)
+
+func test_set_setting_force_silent_false_emits_signal() -> void:
+	# Set initial value
+	Settings.set_setting(test_section, test_key, "initial_value")
+
+	# Create a signal spy
+	var connection := func(): test_set_setting_force_silent_false_emits_signal__signal_emitted = true
+	Signals.settings_changed.connect(connection)
+
+	# Change value with explicit force_silent = false
+	Settings.set_setting(test_section, test_key, "new_value", false)
+	await get_tree().process_frame
+
+	assert_bool(test_set_setting_force_silent_false_emits_signal__signal_emitted).is_true()
+	Signals.settings_changed.disconnect(connection)
+
+func test_set_setting_early_return_with_same_numeric_value() -> void:
+	Settings.set_setting(test_section, test_key, 42)
+
+	var connection := func(): test_set_setting_early_return_with_same_numeric_value__signal_emitted = true
+	Signals.settings_changed.connect(connection)
+
+	Settings.set_setting(test_section, test_key, 42)
+	await get_tree().process_frame
+
+	assert_bool(test_set_setting_early_return_with_same_numeric_value__signal_emitted).is_false()
+	Signals.settings_changed.disconnect(connection)
+
+func test_set_setting_early_return_with_same_boolean_value() -> void:
+	Settings.set_setting(test_section, test_key, true)
+
+	var connection := func(): test_set_setting_early_return_with_same_boolean_value__signal_emitted = true
+	Signals.settings_changed.connect(connection)
+
+	Settings.set_setting(test_section, test_key, true)
+	await get_tree().process_frame
+
+	assert_bool(test_set_setting_early_return_with_same_boolean_value__signal_emitted).is_false()
+	Signals.settings_changed.disconnect(connection)
+
+func test_set_setting_early_return_with_same_float_value() -> void:
+	Settings.set_setting(test_section, test_key, 3.14)
+
+	var connection := func(): test_set_setting_early_return_with_same_float_value__signal_emitted = true
+	Signals.settings_changed.connect(connection)
+
+	Settings.set_setting(test_section, test_key, 3.14)
+	await get_tree().process_frame
+
+	assert_bool(test_set_setting_early_return_with_same_float_value__signal_emitted).is_false()
+	Signals.settings_changed.disconnect(connection)
+
+func test_set_setting_does_not_emit_on_save_error() -> void:
+	# This test verifies that if save fails, signal is not emitted
+	# We can't easily force a save error in tests, but we document the behavior
+	pass
+
+func test_restore_default_emits_settings_changed() -> void:
+	Settings.define_preset(test_section, test_key, "default_val")
+	Settings.set_setting(test_section, test_key, "changed_val")
+
+	var connection := func(): test_restore_default_emits_settings_changed__signal_emitted = true
+	Signals.settings_changed.connect(connection)
+
+	Settings.restore_default(test_section, test_key)
+	await get_tree().process_frame
+
+	assert_bool(test_restore_default_emits_settings_changed__signal_emitted).is_true()
+	Signals.settings_changed.disconnect(connection)
+
+func test_restore_default_no_signal_if_already_default() -> void:
+	Settings.define_preset(test_section, test_key, "default_val")
+	Settings.set_setting(test_section, test_key, "default_val")
+
+	var connection := func(): test_restore_default_no_signal_if_already_default__signal_emitted = true
+	Signals.settings_changed.connect(connection)
+
+	Settings.restore_default(test_section, test_key)
+	await get_tree().process_frame
+
+	# Should not emit because value didn't change (early return)
+	assert_bool(test_restore_default_no_signal_if_already_default__signal_emitted).is_false()
+	Signals.settings_changed.disconnect(connection)

--- a/tests/core/main_test.gd
+++ b/tests/core/main_test.gd
@@ -1,0 +1,170 @@
+# GdUnit generated TestSuite
+class_name MainTestSuite
+extends GdUnitTestSuite
+@warning_ignore('unused_parameter')
+@warning_ignore('return_value_discarded')
+
+# TestSuite generated from
+const __source = 'res://core/main.gd'
+
+var test_section := "editor_ui"
+
+func before_test() -> void:
+	# Store original values
+	pass
+
+func after_test() -> void:
+	# Restore original UI filter settings
+	if Settings.presets.has_section_key(test_section, "filter_hue_shift"):
+		Settings.restore_default(test_section, "filter_hue_shift")
+	if Settings.presets.has_section_key(test_section, "filter_saturation"):
+		Settings.restore_default(test_section, "filter_saturation")
+	if Settings.presets.has_section_key(test_section, "filter_brightness"):
+		Settings.restore_default(test_section, "filter_brightness")
+
+func test_ui_filter_presets_defined() -> void:
+	# Verify UI filter presets are defined
+	assert_bool(Settings.presets.has_section_key(test_section, "filter_hue_shift")).is_true()
+	assert_bool(Settings.presets.has_section_key(test_section, "filter_saturation")).is_true()
+	assert_bool(Settings.presets.has_section_key(test_section, "filter_brightness")).is_true()
+
+func test_ui_filter_hue_shift_default_value() -> void:
+	var default = Settings.get_default(test_section, "filter_hue_shift")
+	assert_float(default).is_equal(0.0)
+
+func test_ui_filter_saturation_default_value() -> void:
+	var default = Settings.get_default(test_section, "filter_saturation")
+	assert_float(default).is_equal(1.0)
+
+func test_ui_filter_brightness_default_value() -> void:
+	var default = Settings.get_default(test_section, "filter_brightness")
+	assert_float(default).is_equal(1.0)
+
+func test_ui_filter_hue_shift_range() -> void:
+	# Test valid hue shift values
+	Settings.set_setting(test_section, "filter_hue_shift", 0.5, true)
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_equal(0.5)
+
+	Settings.set_setting(test_section, "filter_hue_shift", -0.5, true)
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_equal(-0.5)
+
+	Settings.set_setting(test_section, "filter_hue_shift", 1.0, true)
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_equal(1.0)
+
+	Settings.set_setting(test_section, "filter_hue_shift", -1.0, true)
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_equal(-1.0)
+
+func test_ui_filter_saturation_range() -> void:
+	# Test valid saturation values
+	Settings.set_setting(test_section, "filter_saturation", 0.0, true)
+	assert_float(Settings.get_setting(test_section, "filter_saturation")).is_equal(0.0)
+
+	Settings.set_setting(test_section, "filter_saturation", 2.0, true)
+	assert_float(Settings.get_setting(test_section, "filter_saturation")).is_equal(2.0)
+
+	Settings.set_setting(test_section, "filter_saturation", 1.5, true)
+	assert_float(Settings.get_setting(test_section, "filter_saturation")).is_equal(1.5)
+
+func test_ui_filter_brightness_range() -> void:
+	# Test valid brightness values
+	Settings.set_setting(test_section, "filter_brightness", 0.0, true)
+	assert_float(Settings.get_setting(test_section, "filter_brightness")).is_equal(0.0)
+
+	Settings.set_setting(test_section, "filter_brightness", 2.0, true)
+	assert_float(Settings.get_setting(test_section, "filter_brightness")).is_equal(2.0)
+
+	Settings.set_setting(test_section, "filter_brightness", 1.5, true)
+	assert_float(Settings.get_setting(test_section, "filter_brightness")).is_equal(1.5)
+
+func test_ui_filter_shader_parameters_updated() -> void:
+	# This test verifies the shader parameters are set correctly
+	# Note: We can't fully test the visual effect without running the scene
+	# But we can verify the settings are properly stored and retrieved
+	Settings.set_setting(test_section, "filter_hue_shift", 0.25, true)
+	Settings.set_setting(test_section, "filter_saturation", 1.2, true)
+	Settings.set_setting(test_section, "filter_brightness", 0.9, true)
+
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_equal(0.25)
+	assert_float(Settings.get_setting(test_section, "filter_saturation")).is_equal(1.2)
+	assert_float(Settings.get_setting(test_section, "filter_brightness")).is_equal(0.9)
+
+func test_theme_preset_exists() -> void:
+	assert_bool(Settings.presets.has_section_key(test_section, "theme_name")).is_true()
+
+func test_theme_default_value() -> void:
+	var default = Settings.get_default(test_section, "theme_name")
+	assert_str(default).is_equal("dark")
+
+func test_ui_filter_settings_independent() -> void:
+	# Verify that changing one filter setting doesn't affect others
+	var original_saturation = Settings.get_setting(test_section, "filter_saturation")
+	var original_brightness = Settings.get_setting(test_section, "filter_brightness")
+
+	Settings.set_setting(test_section, "filter_hue_shift", 0.5, true)
+
+	assert_float(Settings.get_setting(test_section, "filter_saturation")).is_equal(original_saturation)
+	assert_float(Settings.get_setting(test_section, "filter_brightness")).is_equal(original_brightness)
+
+func test_ui_filter_grayscale_effect() -> void:
+	# Test configuration for grayscale (saturation = 0)
+	Settings.set_setting(test_section, "filter_saturation", 0.0, true)
+	assert_float(Settings.get_setting(test_section, "filter_saturation")).is_equal(0.0)
+
+func test_ui_filter_maximum_saturation() -> void:
+	# Test maximum saturation boost
+	Settings.set_setting(test_section, "filter_saturation", 2.0, true)
+	assert_float(Settings.get_setting(test_section, "filter_saturation")).is_equal(2.0)
+
+func test_ui_filter_dark_mode() -> void:
+	# Test dark mode (reduced brightness)
+	Settings.set_setting(test_section, "filter_brightness", 0.5, true)
+	assert_float(Settings.get_setting(test_section, "filter_brightness")).is_equal(0.5)
+
+func test_ui_filter_bright_mode() -> void:
+	# Test bright mode (increased brightness)
+	Settings.set_setting(test_section, "filter_brightness", 1.5, true)
+	assert_float(Settings.get_setting(test_section, "filter_brightness")).is_equal(1.5)
+
+func test_ui_filter_hue_rotation_positive() -> void:
+	# Test positive hue rotation
+	Settings.set_setting(test_section, "filter_hue_shift", 0.333, true)
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_between(0.332, 0.334)
+
+func test_ui_filter_hue_rotation_negative() -> void:
+	# Test negative hue rotation
+	Settings.set_setting(test_section, "filter_hue_shift", -0.333, true)
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_between(-0.334, -0.332)
+
+func test_ui_filter_reset_to_defaults() -> void:
+	# Change all values
+	Settings.set_setting(test_section, "filter_hue_shift", 0.5, true)
+	Settings.set_setting(test_section, "filter_saturation", 1.5, true)
+	Settings.set_setting(test_section, "filter_brightness", 0.8, true)
+
+	# Reset to defaults
+	Settings.restore_default(test_section, "filter_hue_shift")
+	Settings.restore_default(test_section, "filter_saturation")
+	Settings.restore_default(test_section, "filter_brightness")
+
+	# Verify defaults
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_equal(0.0)
+	assert_float(Settings.get_setting(test_section, "filter_saturation")).is_equal(1.0)
+	assert_float(Settings.get_setting(test_section, "filter_brightness")).is_equal(1.0)
+
+func test_ui_filter_extreme_values() -> void:
+	# Test edge case values
+	Settings.set_setting(test_section, "filter_hue_shift", 1.0, true)
+	Settings.set_setting(test_section, "filter_saturation", 2.0, true)
+	Settings.set_setting(test_section, "filter_brightness", 2.0, true)
+
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_equal(1.0)
+	assert_float(Settings.get_setting(test_section, "filter_saturation")).is_equal(2.0)
+	assert_float(Settings.get_setting(test_section, "filter_brightness")).is_equal(2.0)
+
+	Settings.set_setting(test_section, "filter_hue_shift", -1.0, true)
+	Settings.set_setting(test_section, "filter_saturation", 0.0, true)
+	Settings.set_setting(test_section, "filter_brightness", 0.0, true)
+
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_equal(-1.0)
+	assert_float(Settings.get_setting(test_section, "filter_saturation")).is_equal(0.0)
+	assert_float(Settings.get_setting(test_section, "filter_brightness")).is_equal(0.0)

--- a/tests/core/main_test.gd.uid
+++ b/tests/core/main_test.gd.uid
@@ -1,0 +1,1 @@
+uid://cxtieeep187gv

--- a/tests/core/shader_validation_test.gd
+++ b/tests/core/shader_validation_test.gd
@@ -1,0 +1,138 @@
+# GdUnit generated TestSuite
+class_name ShaderValidationTestSuite
+extends GdUnitTestSuite
+@warning_ignore('unused_parameter')
+@warning_ignore('return_value_discarded')
+
+# TestSuite for validating main.gdshader
+const __shader_source = 'res://core/main.gdshader'
+
+func test_shader_file_exists() -> void:
+	assert_bool(FileAccess.file_exists(__shader_source)).is_true()
+
+func test_shader_loads_successfully() -> void:
+	var shader = load(__shader_source)
+	assert_object(shader).is_not_null()
+	assert_object(shader).is_instanceof(Shader)
+
+func test_shader_has_required_uniforms() -> void:
+	var shader = load(__shader_source) as Shader
+	var code = shader.code
+
+	# Check for required uniform declarations
+	assert_bool(code.contains("uniform float hue_shift")).is_true()
+	assert_bool(code.contains("uniform float saturation")).is_true()
+	assert_bool(code.contains("uniform float brightness")).is_true()
+	assert_bool(code.contains("uniform sampler2D SCREEN_TEXTURE")).is_true()
+
+func test_shader_has_hsv_conversion_functions() -> void:
+	var shader = load(__shader_source) as Shader
+	var code = shader.code
+
+	# Check for RGB to HSV conversion function
+	assert_bool(code.contains("vec3 rgb2hsv(vec3 c)")).is_true()
+	# Check for HSV to RGB conversion function
+	assert_bool(code.contains("vec3 hsv2rgb(vec3 c)")).is_true()
+
+func test_shader_has_fragment_function() -> void:
+	var shader = load(__shader_source) as Shader
+	var code = shader.code
+
+	assert_bool(code.contains("void fragment()")).is_true()
+
+func test_shader_type_is_canvas_item() -> void:
+	var shader = load(__shader_source) as Shader
+	var code = shader.code
+
+	assert_bool(code.contains("shader_type canvas_item")).is_true()
+
+func test_shader_material_can_be_created() -> void:
+	var shader = load(__shader_source) as Shader
+	var material = ShaderMaterial.new()
+	material.shader = shader
+
+	assert_object(material).is_not_null()
+	assert_object(material.shader).is_equal(shader)
+
+func test_shader_default_uniform_values() -> void:
+	var shader = load(__shader_source) as Shader
+	var material = ShaderMaterial.new()
+	material.shader = shader
+
+	# Set default values and verify they can be retrieved
+	material.set_shader_parameter("hue_shift", 0.0)
+	material.set_shader_parameter("saturation", 1.0)
+	material.set_shader_parameter("brightness", 1.0)
+
+	assert_float(material.get_shader_parameter("hue_shift")).is_equal(0.0)
+	assert_float(material.get_shader_parameter("saturation")).is_equal(1.0)
+	assert_float(material.get_shader_parameter("brightness")).is_equal(1.0)
+
+func test_shader_hue_shift_parameter() -> void:
+	var shader = load(__shader_source) as Shader
+	var material = ShaderMaterial.new()
+	material.shader = shader
+
+	# Test various hue shift values
+	material.set_shader_parameter("hue_shift", 0.5)
+	assert_float(material.get_shader_parameter("hue_shift")).is_equal(0.5)
+
+	material.set_shader_parameter("hue_shift", -0.5)
+	assert_float(material.get_shader_parameter("hue_shift")).is_equal(-0.5)
+
+	material.set_shader_parameter("hue_shift", 1.0)
+	assert_float(material.get_shader_parameter("hue_shift")).is_equal(1.0)
+
+func test_shader_saturation_parameter() -> void:
+	var shader = load(__shader_source) as Shader
+	var material = ShaderMaterial.new()
+	material.shader = shader
+
+	material.set_shader_parameter("saturation", 0.0)
+	assert_float(material.get_shader_parameter("saturation")).is_equal(0.0)
+
+	material.set_shader_parameter("saturation", 2.0)
+	assert_float(material.get_shader_parameter("saturation")).is_equal(2.0)
+
+func test_shader_brightness_parameter() -> void:
+	var shader = load(__shader_source) as Shader
+	var material = ShaderMaterial.new()
+	material.shader = shader
+
+	material.set_shader_parameter("brightness", 0.0)
+	assert_float(material.get_shader_parameter("brightness")).is_equal(0.0)
+
+	material.set_shader_parameter("brightness", 2.0)
+	assert_float(material.get_shader_parameter("brightness")).is_equal(2.0)
+
+func test_shader_uid_file_exists() -> void:
+	assert_bool(FileAccess.file_exists("res://core/main.gdshader.uid")).is_true()
+
+func test_shader_uid_format() -> void:
+	var uid_content = FileAccess.get_file_as_string("res://core/main.gdshader.uid").strip_edges()
+	assert_bool(uid_content.begins_with("uid://")).is_true()
+
+func test_color_rect_with_shader_material() -> void:
+	# Test that a ColorRect can use this shader
+	var rect = auto_free(ColorRect.new())
+	var material = ShaderMaterial.new()
+	material.shader = load(__shader_source)
+	rect.material = material
+
+	assert_object(rect.material).is_not_null()
+	assert_object(rect.material).is_instanceof(ShaderMaterial)
+
+func test_shader_all_parameters_together() -> void:
+	var shader = load(__shader_source) as Shader
+	var material = ShaderMaterial.new()
+	material.shader = shader
+
+	# Set all parameters to non-default values
+	material.set_shader_parameter("hue_shift", 0.25)
+	material.set_shader_parameter("saturation", 1.5)
+	material.set_shader_parameter("brightness", 0.8)
+
+	# Verify all can coexist
+	assert_float(material.get_shader_parameter("hue_shift")).is_equal(0.25)
+	assert_float(material.get_shader_parameter("saturation")).is_equal(1.5)
+	assert_float(material.get_shader_parameter("brightness")).is_equal(0.8)

--- a/tests/core/shader_validation_test.gd.uid
+++ b/tests/core/shader_validation_test.gd.uid
@@ -1,0 +1,1 @@
+uid://desi04m2w55yl

--- a/tests/core/ui_filter_integration_test.gd
+++ b/tests/core/ui_filter_integration_test.gd
@@ -1,0 +1,183 @@
+# GdUnit generated TestSuite
+class_name UIFilterIntegrationTestSuite
+extends GdUnitTestSuite
+@warning_ignore('unused_parameter')
+@warning_ignore('return_value_discarded')
+
+# Integration test suite for UI Filter feature (PR #145)
+const __source = 'res://core/main.gd'
+
+var test_section := "editor_ui"
+
+var test_complete_ui_filter_workflow__signal_emitted := false
+var test_multiple_filter_changes_batch__signal_count := 0
+var test_ui_filter_with_silent_mode__signal_count := 0
+var test_settings_changed_signal_propagation__signal_received := false
+var test_no_signal_on_identical_value__signal_count := 0
+
+func before_test() -> void:
+	# Store original values
+	pass
+
+func after_test() -> void:
+	# Restore defaults
+	Settings.restore_default(test_section, "filter_hue_shift")
+	Settings.restore_default(test_section, "filter_saturation")
+	Settings.restore_default(test_section, "filter_brightness")
+
+func test_complete_ui_filter_workflow() -> void:
+	# Test complete workflow: setting -> signal -> reload
+	var connection := func(): test_complete_ui_filter_workflow__signal_emitted = true
+	Signals.settings_changed.connect(connection)
+
+	# Change hue shift
+	Settings.set_setting(test_section, "filter_hue_shift", 0.5)
+	await get_tree().process_frame
+	assert_bool(test_complete_ui_filter_workflow__signal_emitted).is_true()
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_equal(0.5)
+
+	Signals.settings_changed.disconnect(connection)
+
+func test_multiple_filter_changes_batch() -> void:
+	# Test changing multiple filters in sequence
+	var connection := func(): test_multiple_filter_changes_batch__signal_count += 1
+	Signals.settings_changed.connect(connection)
+
+	Settings.set_setting(test_section, "filter_hue_shift", 0.2)
+	Settings.set_setting(test_section, "filter_saturation", 1.3)
+	Settings.set_setting(test_section, "filter_brightness", 0.9)
+	await get_tree().process_frame
+
+	# Should emit signal for each change
+	assert_int(test_multiple_filter_changes_batch__signal_count).is_equal(3)
+
+	Signals.settings_changed.disconnect(connection)
+
+func test_ui_filter_with_silent_mode() -> void:
+	# Test that force_silent prevents signal emission
+	var connection := func(): test_ui_filter_with_silent_mode__signal_count += 1
+	Signals.settings_changed.connect(connection)
+
+	# Change with silent mode
+	Settings.set_setting(test_section, "filter_hue_shift", 0.3, true)
+	Settings.set_setting(test_section, "filter_saturation", 1.4, true)
+	Settings.set_setting(test_section, "filter_brightness", 1.1, true)
+	await get_tree().process_frame
+
+	# No signals should be emitted
+	assert_int(test_ui_filter_with_silent_mode__signal_count).is_equal(0)
+
+	# But values should be changed
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_equal(0.3)
+	assert_float(Settings.get_setting(test_section, "filter_saturation")).is_equal(1.4)
+	assert_float(Settings.get_setting(test_section, "filter_brightness")).is_equal(1.1)
+
+	Signals.settings_changed.disconnect(connection)
+
+func test_ui_filter_preset_consistency() -> void:
+	# Verify all UI filter presets are consistent
+	assert_bool(Settings.presets.has_section_key(test_section, "filter_hue_shift")).is_true()
+	assert_bool(Settings.presets.has_section_key(test_section, "filter_saturation")).is_true()
+	assert_bool(Settings.presets.has_section_key(test_section, "filter_brightness")).is_true()
+	assert_bool(Settings.presets.has_section_key(test_section, "theme_name")).is_true()
+
+func test_ui_filter_color_transformations() -> void:
+	# Test various color transformation scenarios
+
+	# Grayscale (desaturate)
+	Settings.set_setting(test_section, "filter_saturation", 0.0, true)
+	assert_float(Settings.get_setting(test_section, "filter_saturation")).is_equal(0.0)
+
+	# High contrast (max saturation)
+	Settings.set_setting(test_section, "filter_saturation", 2.0, true)
+	assert_float(Settings.get_setting(test_section, "filter_saturation")).is_equal(2.0)
+
+	# Sepia-like (hue shift + desaturate)
+	Settings.set_setting(test_section, "filter_hue_shift", 0.1, true)
+	Settings.set_setting(test_section, "filter_saturation", 0.5, true)
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_equal(0.1)
+	assert_float(Settings.get_setting(test_section, "filter_saturation")).is_equal(0.5)
+
+func test_ui_filter_accessibility_modes() -> void:
+	# Test common accessibility configurations
+
+	# High contrast mode
+	Settings.set_setting(test_section, "filter_saturation", 1.5, true)
+	Settings.set_setting(test_section, "filter_brightness", 1.2, true)
+	assert_float(Settings.get_setting(test_section, "filter_saturation")).is_equal(1.5)
+	assert_float(Settings.get_setting(test_section, "filter_brightness")).is_equal(1.2)
+
+	# Reduced brightness for eye strain
+	Settings.set_setting(test_section, "filter_brightness", 0.7, true)
+	assert_float(Settings.get_setting(test_section, "filter_brightness")).is_equal(0.7)
+
+func test_ui_filter_edge_cases() -> void:
+	# Test edge cases and boundary values
+
+	# Maximum hue shift
+	Settings.set_setting(test_section, "filter_hue_shift", 1.0, true)
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_equal(1.0)
+
+	# Minimum hue shift
+	Settings.set_setting(test_section, "filter_hue_shift", -1.0, true)
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_equal(-1.0)
+
+	# Zero brightness (black screen)
+	Settings.set_setting(test_section, "filter_brightness", 0.0, true)
+	assert_float(Settings.get_setting(test_section, "filter_brightness")).is_equal(0.0)
+
+func test_ui_filter_restore_all_defaults() -> void:
+	# Change all values
+	Settings.set_setting(test_section, "filter_hue_shift", 0.5, true)
+	Settings.set_setting(test_section, "filter_saturation", 1.5, true)
+	Settings.set_setting(test_section, "filter_brightness", 0.8, true)
+
+	# Restore all
+	Settings.restore_default(test_section, "filter_hue_shift")
+	Settings.restore_default(test_section, "filter_saturation")
+	Settings.restore_default(test_section, "filter_brightness")
+
+	# Verify all defaults
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_equal(0.0)
+	assert_float(Settings.get_setting(test_section, "filter_saturation")).is_equal(1.0)
+	assert_float(Settings.get_setting(test_section, "filter_brightness")).is_equal(1.0)
+
+func test_ui_filter_independent_from_theme() -> void:
+	# Verify UI filter settings are independent from theme changes
+	var original_theme = Settings.get_setting(test_section, "theme_name")
+
+	Settings.set_setting(test_section, "filter_hue_shift", 0.5, true)
+	Settings.set_setting(test_section, "theme_name", "light", true)
+
+	# Filter should remain unchanged
+	assert_float(Settings.get_setting(test_section, "filter_hue_shift")).is_equal(0.5)
+
+	# Restore
+	Settings.set_setting(test_section, "theme_name", original_theme, true)
+
+func test_settings_changed_signal_propagation() -> void:
+	# Test that settings_changed signal propagates correctly
+	var connection := func(): test_settings_changed_signal_propagation__signal_received = true
+	Signals.settings_changed.connect(connection)
+
+	# Make a change that should trigger signal
+	Settings.set_setting(test_section, "filter_hue_shift", 0.25)
+	await get_tree().process_frame
+
+	assert_bool(test_settings_changed_signal_propagation__signal_received).is_true()
+	Signals.settings_changed.disconnect(connection)
+
+func test_no_signal_on_identical_value() -> void:
+	# Set initial value
+	Settings.set_setting(test_section, "filter_hue_shift", 0.5, true)
+
+	var connection := func(): test_no_signal_on_identical_value__signal_count += 1
+	Signals.settings_changed.connect(connection)
+
+	# Set same value again
+	Settings.set_setting(test_section, "filter_hue_shift", 0.5)
+	await get_tree().process_frame
+
+	# Should not emit signal (early return)
+	assert_int(test_no_signal_on_identical_value__signal_count).is_equal(0)
+	Signals.settings_changed.disconnect(connection)

--- a/tests/core/ui_filter_integration_test.gd.uid
+++ b/tests/core/ui_filter_integration_test.gd.uid
@@ -1,0 +1,1 @@
+uid://p08v84qb5ucd


### PR DESCRIPTION
## Summary of Changes
- Shift hue, saturation, and brightness of editor without themes
- Real "Dynamic Reload" for settings just when settings change
- Add support for float values in preferences

## Related Items
- Related to #39 and #100
  Themes can change original view of editor, but this UI Filter changes whole colors (just like a filter)

## Technical Details & Testing
- Unnecessary `Signals.settings_changed` emissions removed, currently `Settings` API emits this signal in `set_setting()`. 
- Support for `float` setting values added as *SpinBox*.
- A new `force_silent` property added to `Settings.set_setting()` to avoid `Signals.settings_changed` emissions when needed.
- New `overlay_filter` added to main window of editor to apply UI Filter.
- A shader for UI Filter with `hue_shift`, `saturation`, and `brightness` added:
  - Gets three `hsb` values from settings.
  - Converts screen texture to `HSV`.
  - Applies filter.
  - Converts filtered texture to `RGB`.
  - Sets screen texture to new colors (keeps `alpha` channel`).

## Checklist
<!-- Confirm the following before requesting merge,
keep PR as draft before completing this list. -->
- [x] Linked all relevant issues/PRs/discussions
- [x] Code follows project style and guidelines
- [x] Self-reviewed and tested thoroughly
- [x] Documentation updated (if applicable)
- [x] No new warnings or errors introduced
- [x] Relevant changes added to CHANGELOG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual UI filter overlay (hue, saturation, brightness) and finer float-step control.

* **Improvements**
  * Option to save settings silently (no notification).
  * Preferences window close behavior streamlined to avoid unintended callbacks.
  * Theme changes no longer broadcast a global settings-changed notification by default.

* **Documentation**
  * Added "Customize Editor Appearance" / UI Filter guidance.

* **Tests**
  * Substantial new and expanded tests covering settings, preferences, theme, UI filter, and shader.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->