### PR TITLE
doc: Add export project instructions

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -13,7 +13,7 @@ Text Forge built on Godot (v4.5.stable.official [876b29033]), you can get this v
 ## Get Source
 
 To get source you can use `git clone` or with GitHub Desktop:
-```
+```bash
 git clone https://github.com/text-forge/text-forge.git
 ```
 Or open [official repo](https://github.com/text-forge/text-forge) and click on `Code > Open with GitHub Desktop` and configure it.
@@ -24,4 +24,53 @@ Now you can use Godot to import project and edit it, or press `F5` to run projec
 
 !!! Important
 
-    If your clone is for conribution, Always create a new branch for new PRs.
+    If your clone is for contribution, always create a new branch for new PRs.
+
+## Export Project
+
+### In Godot GUI
+
+1. From the **Project** menu, open **Export**.
+2. Click the **Export Project...** button.
+3. Choose the destination directory.
+!!! Note
+    Currently, you must enable the **Export With Debug** option to ensure all required files are included.
+
+4. After exporting, copy the `data` and `action_scripts` directories to the same output directory.
+
+### In CLI (Linux)
+First get Godot
+
+You also need Godot templates (Godot_v{version}-stable_export_templates.tpz)
+They can be downloaded from Godot's [GitHub](https://github.com/godotengine/godot/releases)
+(Preferred version is 4.5 stable)
+
+Then extract .tpz templates
+```bash
+unzip Godot_v4.5-stable_export_templates.tpz
+cd templates
+mkdir -p ~/.local/share/godot/export_templates/4.5.stable/
+cp templates/* ~/.local/share/godot/export_templates/4.5.stable/
+```
+In your cloned or extracted Text-Forge project directory, run:
+
+Import Text-Forge project into Godot first
+```bash
+godot --headless --import
+```
+
+Export Text-Forge
+```bash
+Godot_v4.5-stable_linux.x86_64 <path/to/text-forge/project.godot> --headless --export-debug Linux <output/path/TextForge.x86_64> --verbose --quit
+```
+If you have Godot installed globally or available in your PATH as godot:
+```bash
+godot --verbose --headless $(pwd)/project.godot --export-debug Linux $(pwd)/TextForge.x86_64 --quit
+```
+
+Run the exported binary:
+```bash
+./TextForge.x86_64
+```
+
+**Note:** If you want TextForge in a different directory, copy the binaries and directories `data` and `action_scripts` to your desired location.


### PR DESCRIPTION
Add instructions for exporting TextForge from project files

## Related Items
- Closes #154

## Checklist
- [x] **I have thoroughly read the [Branch Merge Policy](https://github.com/text-forge/text-forge/wiki/Branch-Merge-Policy) and will follow it.**
- [x] Linked all relevant issues/PRs/discussions
- [x] Code follows project style and guidelines
- [x] Self-reviewed and tested thoroughly
- [x] Documentation updated (if applicable)
- [x] No new warnings or errors introduced
- [ ] Relevant changes added to CHANGELOG

Since I am still learning english..  
I need help with gramar and sentences etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Export Project" guide covering GUI and Linux CLI workflows: prerequisites, step-by-step export/import, post-export asset placement, enabling debug exports, handling export templates, custom output directories, and how to run exported binaries.
  * Replaced a generic code fence with a Bash-specific fence for cloning.
  * Fixed a typographical error ("contribution") and normalized note capitalization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->